### PR TITLE
docs: fix package name for fuse3 on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ```shell
 sudo pacman -S fuse3 --noconfirm # archlinux
-sudo apt-get -y install fuse     # debian/ubuntu
+sudo apt-get -y install fuse3    # debian/ubuntu
 ```
 
 ### Load `FUSE` kernel module on FreeBSD


### PR DESCRIPTION
# Which issue does this PR close?

When only `fuse` is installed, running `ofs` will lead to the following error:

```
Error: find fusermount3 binary failed CannotFindBinaryPath
```

# Rationale for this change

It seems that `fusermount3` is provided in

- [22.04](https://manpages.ubuntu.com/manpages/jammy/en/man1/fusermount3.1.html)
- [25.04](https://manpages.ubuntu.com/manpages/plucky/en/man1/fusermount3.1.html)
- [26.04](https://manpages.ubuntu.com/manpages/resolute/en/man1/fusermount3.1.html)

But only not in [24.04](https://manpages.ubuntu.com/manpages/noble/en/man1/fusermount3.1.html).

After checking, on Ubuntu 24.04, `fusermount3` is also provided in `fuse3` package:

```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04.1 LTS
Release:	24.04
Codename:	noble
$ dpkg -L fuse3
/.
/bin
diverted by base-files to: /bin.usr-is-merged
/bin/fusermount3
/etc
/etc/fuse.conf
/sbin
diverted by base-files to: /sbin.usr-is-merged
/sbin/mount.fuse3
/usr
/usr/share
/usr/share/doc
/usr/share/doc/fuse3
/usr/share/doc/fuse3/copyright
/usr/share/initramfs-tools
/usr/share/initramfs-tools/hooks
/usr/share/initramfs-tools/hooks/fuse
/usr/share/man
/usr/share/man/man1
/usr/share/man/man1/fusermount3.1.gz
/usr/share/man/man8
/usr/share/man/man8/mount.fuse3.8.gz
/bin/fusermount
/sbin/mount.fuse
/usr/share/doc/fuse3/changelog.Debian.gz
/usr/share/man/man1/fusermount.1.gz
/usr/share/man/man8/mount.fuse.8.gz
```

It seems to be a typo in their man page.

# What changes are included in this PR?

Just changing the doc.

But I think it may be better to include some basic and actual (integration) tests to check the deps. Feel free to ask me to add them ;)

# Are there any user-facing changes?

Nope