### PR TITLE
chore: sync opendal deps and tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,26 +15,28 @@
 # specific language governing permissions and limitations
 # under the License.
 
-[package]
-description = "fuse3 integration for Apache OpenDAL"
-name = "fuse3_opendal"
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: "yearly"
 
-authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
-edition = "2024"
-homepage = "https://opendal.apache.org/"
-license = "Apache-2.0"
-repository = "https://github.com/apache/opendal"
-rust-version = "1.85"
-version = "0.0.19"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: "monthly"
 
-[dependencies]
-bytes = "1.6.0"
-fuse3 = { version = "0.8.1", "features" = ["tokio-runtime", "unprivileged"] }
-futures-util = "0.3.30"
-libc = "0.2.155"
-log = "0.4.21"
-opendal = { version = "0.55.0" }
-sharded-slab = "0.1.7"
-tokio = "1.38.0"
+  - package-ecosystem: "cargo"
+    directory: "/integrations/fuse3"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: "monthly"
 
-[dev-dependencies]
+  - package-ecosystem: "cargo"
+    directory: "/integrations/cloud_filter"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ on:
       - main
     paths:
       - "src/**"
+      - "tests/**"
+      - "integrations/**"
+      - "scripts/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
       - ".github/workflows/ci.yml"
 
 concurrency:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,28 +103,13 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backon"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
  "gloo-timers",
  "tokio",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
 ]
 
 [[package]]
@@ -661,12 +631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,17 +912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,15 +1129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,15 +1190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ofs"
 version = "0.0.24"
 dependencies = [
@@ -1290,21 +1225,21 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "opendal"
-version = "0.54.1"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42afda58fa2cf50914402d132cc1caacff116a85d10c72ab2082bb7c50021754"
+checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
 dependencies = [
  "anyhow",
  "backon",
  "base64",
  "bytes",
- "chrono",
  "crc32c",
  "dotenvy",
  "futures",
  "getrandom 0.2.16",
  "http",
  "http-body",
+ "jiff",
  "log",
  "md-5",
  "percent-encoding",
@@ -1316,6 +1251,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "url",
  "uuid",
 ]
 
@@ -1581,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.23"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -1643,12 +1579,6 @@ dependencies = [
  "cfg-if",
  "ordered-multimap",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -2141,28 +2071,25 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2209,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ anyhow = { version = "1" }
 clap = { version = "4.5.40", features = ["derive", "env"] }
 log = { version = "0.4.22" }
 logforth = { version = "0.28.1", features = ["starter-log"] }
-opendal = { version = "0.54.0" }
+opendal = { version = "0.55.0" }
 tokio = { version = "1.47.0", features = [
   "fs",
   "macros",
@@ -60,7 +60,7 @@ services-fs = ["opendal/services-fs"]
 services-s3 = ["opendal/services-s3"]
 
 [dev-dependencies]
-opendal = { version = "0.54.0", features = ["tests"] }
+opendal = { version = "0.55.0", features = ["tests"] }
 tempfile = "3.23.0"
 test-context = "0.4.1"
 walkdir = "2.5.0"

--- a/DEPENDENCIES.rust.tsv
+++ b/DEPENDENCIES.rust.tsv
@@ -1,246 +1,266 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-addr2line@0.24.2		X								X
-adler2@2.0.0	X	X								X
-aho-corasick@1.1.3										X		X
-android-tzdata@0.1.1		X								X
-android_system_properties@0.1.5		X								X
-anstream@0.6.18		X								X
-anstyle@1.0.10		X								X
-anstyle-parse@0.2.6		X								X
-anstyle-query@1.1.2		X								X
-anstyle-wincon@3.0.7		X								X
-anyhow@1.0.98		X								X
-async-notify@0.3.0										X
-async-trait@0.1.88		X								X
-autocfg@1.4.0		X								X
-backon@1.5.0		X
-backtrace@0.3.75		X								X
-base64@0.22.1		X								X
-bincode@1.3.3										X
-bitflags@2.9.1		X								X
-block-buffer@0.10.4		X								X
-bumpalo@3.17.0		X								X
-bytes@1.10.1										X
-cc@1.2.23		X								X
-cfg-if@1.0.0		X								X
-cfg_aliases@0.2.1										X
-chrono@0.4.41		X								X
-clap@4.5.40		X								X
-clap_builder@4.5.40		X								X
-clap_derive@4.5.40		X								X
-clap_lex@0.7.4		X								X
-cloud-filter@0.0.6										X
-cloud_filter_opendal@0.0.12		X
-colorchoice@1.0.3		X								X
-concurrent-queue@2.5.0		X								X
-const-oid@0.9.6		X								X
-core-foundation-sys@0.8.7		X								X
-cpufeatures@0.2.17		X								X
-crc32c@0.6.8		X								X
-crossbeam-utils@0.8.21		X								X
-crypto-common@0.1.6		X								X
-deranged@0.4.0		X								X
-digest@0.10.7		X								X
-displaydoc@0.2.5		X								X
-dotenvy@0.15.7										X
-either@1.15.0		X								X
-env_filter@0.1.3		X								X
-errno@0.3.12		X								X
-event-listener@4.0.3		X								X
-fastrand@2.3.0		X								X
-flagset@0.4.7		X
-fnv@1.0.7		X								X
-form_urlencoded@1.2.1		X								X
-fuse3@0.8.1										X
-fuse3_opendal@0.0.19		X
-futures@0.3.31		X								X
-futures-channel@0.3.31		X								X
-futures-core@0.3.31		X								X
-futures-executor@0.3.31		X								X
-futures-io@0.3.31		X								X
-futures-macro@0.3.31		X								X
-futures-sink@0.3.31		X								X
-futures-task@0.3.31		X								X
-futures-util@0.3.31		X								X
-generic-array@0.14.7										X
-getrandom@0.2.16		X								X
-getrandom@0.3.3		X								X
-gimli@0.31.1		X								X
-gloo-timers@0.3.0		X								X
-heck@0.5.0		X								X
-hex@0.4.3		X								X
-hmac@0.12.1		X								X
-home@0.5.11		X								X
-http@1.3.1		X								X
-http-body@1.0.1										X
-http-body-util@0.1.3										X
-httparse@1.10.1		X								X
-hyper@1.6.0										X
-hyper-rustls@0.27.5		X						X		X
-hyper-util@0.1.12										X
-iana-time-zone@0.1.63		X								X
-iana-time-zone-haiku@0.1.2		X								X
-icu_collections@2.0.0											X
-icu_locale_core@2.0.0											X
-icu_normalizer@2.0.0											X
-icu_normalizer_data@2.0.0											X
-icu_properties@2.0.1											X
-icu_properties_data@2.0.1											X
-icu_provider@2.0.0											X
-idna@1.0.3		X								X
-idna_adapter@1.2.1		X								X
-io-uring@0.7.8		X								X
-ipnet@2.11.0		X								X
-iri-string@0.7.8		X								X
-is_terminal_polyfill@1.70.1		X								X
-itoa@1.0.15		X								X
-jiff@0.2.14										X		X
-jiff-tzdb@0.1.4										X		X
-jiff-tzdb-platform@0.1.3										X		X
-js-sys@0.3.77		X								X
-lazy_static@1.5.0		X								X
-libc@0.2.172		X								X
-linux-raw-sys@0.4.15		X	X							X
-litemap@0.8.0											X
-log@0.4.27		X								X
-logforth@0.27.0		X
-md-5@0.10.6		X								X
-memchr@2.7.4										X		X
-memoffset@0.9.1										X
-miniz_oxide@0.8.8		X								X			X
-mio@1.0.3										X
-nix@0.29.0										X
-nix@0.30.1										X
-nt-time@0.8.1		X								X
-num-conv@0.1.0		X								X
-num-traits@0.2.19		X								X
-object@0.36.7		X								X
-ofs@0.0.24		X
-once_cell@1.21.3		X								X
-opendal@0.54.1		X
-parking@2.2.1		X								X
-percent-encoding@2.3.1		X								X
-pin-project-lite@0.2.16		X								X
-pin-utils@0.1.0		X								X
-portable-atomic@1.11.0		X								X
-portable-atomic-util@0.2.4		X								X
-potential_utf@0.1.2											X
-powerfmt@0.2.0		X								X
-ppv-lite86@0.2.21		X								X
-proc-macro2@1.0.95		X								X
-quick-xml@0.37.5										X
-quick-xml@0.38.0										X
-quote@1.0.40		X								X
-r-efi@5.2.0		X							X	X
-rand@0.8.5		X								X
-rand_chacha@0.3.1		X								X
-rand_core@0.6.4		X								X
-regex@1.11.1		X								X
-regex-automata@0.4.9		X								X
-regex-syntax@0.8.5		X								X
-reqsign@0.16.5		X
-reqwest@0.12.22		X								X
-ring@0.17.14		X						X
-rustc-demangle@0.1.24		X								X
-rustc_version@0.4.1		X								X
-rustix@0.38.44		X	X							X
-rustls@0.23.27		X						X		X
-rustls-pki-types@1.12.0		X								X
-rustls-webpki@0.103.3								X
-rustversion@1.0.20		X								X
-ryu@1.0.20		X				X
-semver@1.0.26		X								X
-serde@1.0.219		X								X
-serde_derive@1.0.219		X								X
-serde_json@1.0.140		X								X
-serde_urlencoded@0.7.1		X								X
-sha1@0.10.6		X								X
-sha2@0.10.9		X								X
-sharded-slab@0.1.7										X
-shlex@1.3.0		X								X
-signal-hook-registry@1.4.5		X								X
-slab@0.4.9										X
-smallvec@1.15.0		X								X
-socket2@0.5.9		X								X
-socket2@0.6.0		X								X
-stable_deref_trait@1.2.0		X								X
-strsim@0.11.1										X
-subtle@2.6.1					X
-syn@2.0.101		X								X
-sync_wrapper@1.0.2		X
-synstructure@0.13.2										X
-time@0.3.41		X								X
-time-core@0.1.4		X								X
-time-macros@0.2.22		X								X
-tinystr@0.8.1											X
-tokio@1.47.0										X
-tokio-macros@2.5.0										X
-tokio-rustls@0.26.2		X								X
-tokio-util@0.7.15										X
-tower@0.5.2										X
-tower-http@0.6.6										X
-tower-layer@0.3.3										X
-tower-service@0.3.3										X
-tracing@0.1.41										X
-tracing-attributes@0.1.28										X
-tracing-core@0.1.33										X
-trait-make@0.1.0		X								X
-try-lock@0.2.5										X
-typenum@1.18.0		X								X
-unicode-ident@1.0.18		X								X	X
-untrusted@0.9.0								X
-url@2.5.4		X								X
-utf8_iter@1.0.4		X								X
-utf8parse@0.2.2		X								X
-uuid@1.17.0		X								X
-version_check@0.9.5		X								X
-want@0.3.1										X
-wasi@0.11.0+wasi-snapshot-preview1		X	X							X
-wasi@0.14.2+wasi-0.2.4		X	X							X
-wasm-bindgen@0.2.100		X								X
-wasm-bindgen-backend@0.2.100		X								X
-wasm-bindgen-futures@0.4.50		X								X
-wasm-bindgen-macro@0.2.100		X								X
-wasm-bindgen-macro-support@0.2.100		X								X
-wasm-bindgen-shared@0.2.100		X								X
-wasm-streams@0.4.2		X								X
-web-sys@0.3.77		X								X
-webpki-roots@0.26.11							X
-webpki-roots@1.0.0							X
-which@6.0.3										X
-widestring@1.2.0		X								X
-windows@0.58.0		X								X
-windows-core@0.58.0		X								X
-windows-core@0.61.2		X								X
-windows-implement@0.58.0		X								X
-windows-implement@0.60.0		X								X
-windows-interface@0.58.0		X								X
-windows-interface@0.59.1		X								X
-windows-link@0.1.1		X								X
-windows-result@0.2.0		X								X
-windows-result@0.3.4		X								X
-windows-strings@0.1.0		X								X
-windows-strings@0.4.2		X								X
-windows-sys@0.52.0		X								X
-windows-sys@0.59.0		X								X
-windows-targets@0.52.6		X								X
-windows_aarch64_gnullvm@0.52.6		X								X
-windows_aarch64_msvc@0.52.6		X								X
-windows_i686_gnu@0.52.6		X								X
-windows_i686_gnullvm@0.52.6		X								X
-windows_i686_msvc@0.52.6		X								X
-windows_x86_64_gnu@0.52.6		X								X
-windows_x86_64_gnullvm@0.52.6		X								X
-windows_x86_64_msvc@0.52.6		X								X
-winsafe@0.0.19										X
-wit-bindgen-rt@0.39.0		X	X							X
-writeable@0.6.1											X
-yoke@0.8.0											X
-yoke-derive@0.8.0											X
-zerocopy@0.8.25		X		X						X
-zerofrom@0.1.6											X
-zerofrom-derive@0.1.6											X
-zeroize@1.8.1		X								X
-zerotrie@0.2.2											X
-zerovec@0.11.2											X
-zerovec-derive@0.11.1											X
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MPL-2.0	Unicode-3.0	Unlicense
+android_system_properties@0.1.5	X								X			
+anstream@0.6.21	X								X			
+anstyle@1.0.13	X								X			
+anstyle-parse@0.2.7	X								X			
+anstyle-query@1.1.4	X								X			
+anstyle-wincon@3.0.10	X								X			
+anyhow@1.0.100	X								X			
+async-notify@0.3.0									X			
+async-trait@0.1.89	X								X			
+atomic-waker@1.1.2	X								X			
+autocfg@1.5.0	X								X			
+backon@1.6.0	X											
+base64@0.22.1	X								X			
+bincode@1.3.3									X			
+bitflags@2.9.4	X								X			
+block-buffer@0.10.4	X								X			
+bumpalo@3.19.0	X								X			
+bytes@1.10.1									X			
+cc@1.2.40	X								X			
+cfg-if@1.0.3	X								X			
+cfg_aliases@0.2.1									X			
+chrono@0.4.42	X								X			
+clap@4.5.48	X								X			
+clap_builder@4.5.48	X								X			
+clap_derive@4.5.47	X								X			
+clap_lex@0.7.5	X								X			
+cloud-filter@0.0.6									X			
+cloud_filter_opendal@0.0.12	X											
+colorchoice@1.0.4	X								X			
+colored@3.0.0										X		
+concurrent-queue@2.5.0	X								X			
+const-oid@0.9.6	X								X			
+core-foundation-sys@0.8.7	X								X			
+cpufeatures@0.2.17	X								X			
+crc32c@0.6.8	X								X			
+crossbeam-utils@0.8.21	X								X			
+crypto-common@0.1.6	X								X			
+deranged@0.5.4	X								X			
+digest@0.10.7	X								X			
+displaydoc@0.2.5	X								X			
+dotenvy@0.15.7									X			
+either@1.15.0	X								X			
+erased-serde@0.4.8	X								X			
+errno@0.3.14	X								X			
+event-listener@4.0.3	X								X			
+fastrand@2.3.0	X								X			
+find-msvc-tools@0.1.3	X								X			
+flagset@0.4.7	X											
+fnv@1.0.7	X								X			
+form_urlencoded@1.2.2	X								X			
+fuse3@0.8.1									X			
+fuse3_opendal@0.0.19	X											
+futures@0.3.31	X								X			
+futures-channel@0.3.31	X								X			
+futures-core@0.3.31	X								X			
+futures-executor@0.3.31	X								X			
+futures-io@0.3.31	X								X			
+futures-macro@0.3.31	X								X			
+futures-sink@0.3.31	X								X			
+futures-task@0.3.31	X								X			
+futures-util@0.3.31	X								X			
+generic-array@0.14.7									X			
+getrandom@0.2.16	X								X			
+getrandom@0.3.3	X								X			
+gloo-timers@0.3.0	X								X			
+heck@0.5.0	X								X			
+hex@0.4.3	X								X			
+hmac@0.12.1	X								X			
+home@0.5.11	X								X			
+http@1.3.1	X								X			
+http-body@1.0.1									X			
+http-body-util@0.1.3									X			
+httparse@1.10.1	X								X			
+hyper@1.7.0									X			
+hyper-rustls@0.27.7	X						X		X			
+hyper-util@0.1.17									X			
+iana-time-zone@0.1.64	X								X			
+iana-time-zone-haiku@0.1.2	X								X			
+icu_collections@2.0.0											X	
+icu_locale_core@2.0.0											X	
+icu_normalizer@2.0.0											X	
+icu_normalizer_data@2.0.0											X	
+icu_properties@2.0.1											X	
+icu_properties_data@2.0.1											X	
+icu_provider@2.0.0											X	
+idna@1.1.0	X								X			
+idna_adapter@1.2.1	X								X			
+ipnet@2.11.0	X								X			
+iri-string@0.7.8	X								X			
+is_terminal_polyfill@1.70.1	X								X			
+itoa@1.0.15	X								X			
+jiff@0.2.15									X			X
+jiff-tzdb@0.1.4									X			X
+jiff-tzdb-platform@0.1.3									X			X
+js-sys@0.3.81	X								X			
+lazy_static@1.5.0	X								X			
+libc@0.2.176	X								X			
+linux-raw-sys@0.4.15	X	X							X			
+litemap@0.8.0											X	
+log@0.4.28	X								X			
+logforth@0.28.1	X											
+logforth-append-file@0.2.1	X											
+logforth-bridge-log@0.2.1	X											
+logforth-core@0.2.1	X											
+logforth-layout-json@0.2.1	X											
+logforth-layout-text@0.2.1	X											
+md-5@0.10.6	X								X			
+memchr@2.7.6									X			X
+memoffset@0.9.1									X			
+mio@1.0.4									X			
+nix@0.29.0									X			
+nix@0.30.1									X			
+nt-time@0.8.1	X								X			
+num-conv@0.1.0	X								X			
+num-traits@0.2.19	X								X			
+ofs@0.0.24	X											
+once_cell@1.21.3	X								X			
+once_cell_polyfill@1.70.1	X								X			
+opendal@0.55.0	X											
+parking@2.2.1	X								X			
+percent-encoding@2.3.2	X								X			
+pin-project-lite@0.2.16	X								X			
+pin-utils@0.1.0	X								X			
+portable-atomic@1.11.1	X								X			
+portable-atomic-util@0.2.4	X								X			
+potential_utf@0.1.3											X	
+powerfmt@0.2.0	X								X			
+ppv-lite86@0.2.21	X								X			
+proc-macro2@1.0.101	X								X			
+quick-xml@0.37.5									X			
+quick-xml@0.38.3									X			
+quote@1.0.41	X								X			
+r-efi@5.3.0	X							X	X			
+rand@0.8.5	X								X			
+rand_chacha@0.3.1	X								X			
+rand_core@0.6.4	X								X			
+reqsign@0.16.5	X											
+reqwest@0.12.28	X								X			
+ring@0.17.14	X						X					
+rustc_version@0.4.1	X								X			
+rustix@0.38.44	X	X							X			
+rustls@0.23.32	X						X		X			
+rustls-pki-types@1.12.0	X								X			
+rustls-webpki@0.103.7							X					
+rustversion@1.0.22	X								X			
+ryu@1.0.20	X				X							
+semver@1.0.27	X								X			
+serde@1.0.228	X								X			
+serde_buf@0.1.1	X								X			
+serde_core@1.0.228	X								X			
+serde_derive@1.0.228	X								X			
+serde_fmt@1.0.3	X								X			
+serde_json@1.0.145	X								X			
+serde_urlencoded@0.7.1	X								X			
+sha1@0.10.6	X								X			
+sha2@0.10.9	X								X			
+sharded-slab@0.1.7									X			
+shlex@1.3.0	X								X			
+signal-hook-registry@1.4.6	X								X			
+slab@0.4.11									X			
+smallvec@1.15.1	X								X			
+socket2@0.6.0	X								X			
+stable_deref_trait@1.2.0	X								X			
+strsim@0.11.1									X			
+subtle@2.6.1				X								
+sval@2.15.0	X								X			
+sval_buffer@2.15.0	X								X			
+sval_dynamic@2.15.0	X								X			
+sval_fmt@2.15.0	X								X			
+sval_nested@2.15.0	X								X			
+sval_ref@2.15.0	X								X			
+sval_serde@2.15.0	X								X			
+syn@2.0.106	X								X			
+sync_wrapper@1.0.2	X											
+synstructure@0.13.2									X			
+time@0.3.44	X								X			
+time-core@0.1.6	X								X			
+time-macros@0.2.24	X								X			
+tinystr@0.8.1											X	
+tokio@1.49.0									X			
+tokio-macros@2.6.0									X			
+tokio-rustls@0.26.4	X								X			
+tokio-util@0.7.16									X			
+tower@0.5.2									X			
+tower-http@0.6.8									X			
+tower-layer@0.3.3									X			
+tower-service@0.3.3									X			
+tracing@0.1.41									X			
+tracing-attributes@0.1.30									X			
+tracing-core@0.1.34									X			
+trait-make@0.1.0	X								X			
+try-lock@0.2.5									X			
+typeid@1.0.3	X								X			
+typenum@1.19.0	X								X			
+unicode-ident@1.0.19	X								X		X	
+untrusted@0.9.0							X					
+url@2.5.7	X								X			
+utf8_iter@1.0.4	X								X			
+utf8parse@0.2.2	X								X			
+uuid@1.18.1	X								X			
+value-bag@1.11.1	X								X			
+value-bag-serde1@1.11.1	X								X			
+value-bag-sval2@1.11.1	X								X			
+version_check@0.9.5	X								X			
+want@0.3.1									X			
+wasi@0.11.1+wasi-snapshot-preview1	X	X							X			
+wasi@0.14.7+wasi-0.2.4	X	X							X			
+wasip2@1.0.1+wasi-0.2.4	X	X							X			
+wasm-bindgen@0.2.104	X								X			
+wasm-bindgen-backend@0.2.104	X								X			
+wasm-bindgen-futures@0.4.54	X								X			
+wasm-bindgen-macro@0.2.104	X								X			
+wasm-bindgen-macro-support@0.2.104	X								X			
+wasm-bindgen-shared@0.2.104	X								X			
+wasm-streams@0.4.2	X								X			
+web-sys@0.3.81	X								X			
+webpki-roots@1.0.3						X						
+which@6.0.3									X			
+widestring@1.2.0	X								X			
+windows@0.58.0	X								X			
+windows-core@0.58.0	X								X			
+windows-core@0.62.2	X								X			
+windows-implement@0.58.0	X								X			
+windows-implement@0.60.2	X								X			
+windows-interface@0.58.0	X								X			
+windows-interface@0.59.3	X								X			
+windows-link@0.2.1	X								X			
+windows-result@0.2.0	X								X			
+windows-result@0.4.1	X								X			
+windows-strings@0.1.0	X								X			
+windows-strings@0.5.1	X								X			
+windows-sys@0.52.0	X								X			
+windows-sys@0.59.0	X								X			
+windows-sys@0.60.2	X								X			
+windows-sys@0.61.2	X								X			
+windows-targets@0.52.6	X								X			
+windows-targets@0.53.5	X								X			
+windows_aarch64_gnullvm@0.52.6	X								X			
+windows_aarch64_gnullvm@0.53.1	X								X			
+windows_aarch64_msvc@0.52.6	X								X			
+windows_aarch64_msvc@0.53.1	X								X			
+windows_i686_gnu@0.52.6	X								X			
+windows_i686_gnu@0.53.1	X								X			
+windows_i686_gnullvm@0.52.6	X								X			
+windows_i686_gnullvm@0.53.1	X								X			
+windows_i686_msvc@0.52.6	X								X			
+windows_i686_msvc@0.53.1	X								X			
+windows_x86_64_gnu@0.52.6	X								X			
+windows_x86_64_gnu@0.53.1	X								X			
+windows_x86_64_gnullvm@0.52.6	X								X			
+windows_x86_64_gnullvm@0.53.1	X								X			
+windows_x86_64_msvc@0.52.6	X								X			
+windows_x86_64_msvc@0.53.1	X								X			
+winsafe@0.0.19									X			
+wit-bindgen@0.46.0	X	X							X			
+writeable@0.6.1											X	
+yoke@0.8.0											X	
+yoke-derive@0.8.0											X	
+zerocopy@0.8.27	X		X						X			
+zerofrom@0.1.6											X	
+zerofrom-derive@0.1.6											X	
+zeroize@1.8.2	X								X			
+zerotrie@0.2.2											X	
+zerovec@0.11.4											X	
+zerovec-derive@0.11.1											X	

--- a/integrations/cloud_filter/Cargo.toml
+++ b/integrations/cloud_filter/Cargo.toml
@@ -35,13 +35,13 @@ bincode = "1.3.3"
 cloud-filter = "0.0.6"
 futures = "0.3.30"
 log = "0.4.17"
-opendal = { version = "0.54.0" }
+opendal = { version = "0.55.0" }
 serde = { version = "1.0.203", features = ["derive"] }
 
 [dev-dependencies]
 libtest-mimic = { version = "0.8.1" }
 logforth = { version = "0.23.1", default-features = false }
-opendal = { version = "0.54.0", features = [
+opendal = { version = "0.55.0", features = [
   "services-fs",
   "tests",
 ] }

--- a/integrations/cloud_filter/DEPENDENCIES.rust.tsv
+++ b/integrations/cloud_filter/DEPENDENCIES.rust.tsv
@@ -1,199 +1,208 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-addr2line@0.24.2		X								X
-adler2@2.0.1	X	X								X
-android-tzdata@0.1.1		X								X
-android_system_properties@0.1.5		X								X
-anyhow@1.0.98		X								X
-async-trait@0.1.88		X								X
-autocfg@1.5.0		X								X
-backon@1.5.1		X
-backtrace@0.3.75		X								X
-base64@0.22.1		X								X
-bincode@1.3.3										X
-bitflags@2.9.1		X								X
-block-buffer@0.10.4		X								X
-bumpalo@3.19.0		X								X
-bytes@1.10.1										X
-cc@1.2.29		X								X
-cfg-if@1.0.1		X								X
-chrono@0.4.41		X								X
-cloud-filter@0.0.6										X
-cloud_filter_opendal@0.0.12		X
-const-oid@0.9.6		X								X
-core-foundation-sys@0.8.7		X								X
-cpufeatures@0.2.17		X								X
-crc32c@0.6.8		X								X
-crypto-common@0.1.6		X								X
-deranged@0.4.0		X								X
-digest@0.10.7		X								X
-displaydoc@0.2.5		X								X
-dotenvy@0.15.7										X
-fastrand@2.3.0		X								X
-flagset@0.4.7		X
-fnv@1.0.7		X								X
-form_urlencoded@1.2.1		X								X
-futures@0.3.31		X								X
-futures-channel@0.3.31		X								X
-futures-core@0.3.31		X								X
-futures-executor@0.3.31		X								X
-futures-io@0.3.31		X								X
-futures-macro@0.3.31		X								X
-futures-sink@0.3.31		X								X
-futures-task@0.3.31		X								X
-futures-util@0.3.31		X								X
-generic-array@0.14.7										X
-getrandom@0.2.16		X								X
-getrandom@0.3.3		X								X
-gimli@0.31.1		X								X
-gloo-timers@0.3.0		X								X
-hex@0.4.3		X								X
-hmac@0.12.1		X								X
-home@0.5.11		X								X
-http@1.3.1		X								X
-http-body@1.0.1										X
-http-body-util@0.1.3										X
-httparse@1.10.1		X								X
-hyper@1.6.0										X
-hyper-rustls@0.27.7		X						X		X
-hyper-util@0.1.15										X
-iana-time-zone@0.1.63		X								X
-iana-time-zone-haiku@0.1.2		X								X
-icu_collections@2.0.0											X
-icu_locale_core@2.0.0											X
-icu_normalizer@2.0.0											X
-icu_normalizer_data@2.0.0											X
-icu_properties@2.0.1											X
-icu_properties_data@2.0.1											X
-icu_provider@2.0.0											X
-idna@1.0.3		X								X
-idna_adapter@1.2.1		X								X
-io-uring@0.7.8		X								X
-ipnet@2.11.0		X								X
-iri-string@0.7.8		X								X
-itoa@1.0.15		X								X
-js-sys@0.3.77		X								X
-libc@0.2.174		X								X
-litemap@0.8.0											X
-log@0.4.27		X								X
-md-5@0.10.6		X								X
-memchr@2.7.5										X		X
-memoffset@0.9.1										X
-miniz_oxide@0.8.9		X								X			X
-mio@1.0.4										X
-nt-time@0.8.1		X								X
-num-conv@0.1.0		X								X
-num-traits@0.2.19		X								X
-object@0.36.7		X								X
-once_cell@1.21.3		X								X
-opendal@0.54.1		X
-percent-encoding@2.3.1		X								X
-pin-project-lite@0.2.16		X								X
-pin-utils@0.1.0		X								X
-potential_utf@0.1.2											X
-powerfmt@0.2.0		X								X
-ppv-lite86@0.2.21		X								X
-proc-macro2@1.0.95		X								X
-quick-xml@0.37.5										X
-quick-xml@0.38.0										X
-quote@1.0.40		X								X
-r-efi@5.3.0		X							X	X
-rand@0.8.5		X								X
-rand_chacha@0.3.1		X								X
-rand_core@0.6.4		X								X
-reqsign@0.16.5		X
-reqwest@0.12.22		X								X
-ring@0.17.14		X						X
-rustc-demangle@0.1.25		X								X
-rustc_version@0.4.1		X								X
-rustls@0.23.29		X						X		X
-rustls-pki-types@1.12.0		X								X
-rustls-webpki@0.103.4								X
-rustversion@1.0.21		X								X
-ryu@1.0.20		X				X
-semver@1.0.26		X								X
-serde@1.0.219		X								X
-serde_derive@1.0.219		X								X
-serde_json@1.0.140		X								X
-serde_urlencoded@0.7.1		X								X
-sha1@0.10.6		X								X
-sha2@0.10.9		X								X
-shlex@1.3.0		X								X
-signal-hook-registry@1.4.5		X								X
-slab@0.4.10										X
-smallvec@1.15.1		X								X
-socket2@0.5.10		X								X
-socket2@0.6.0		X								X
-stable_deref_trait@1.2.0		X								X
-subtle@2.6.1					X
-syn@2.0.104		X								X
-sync_wrapper@1.0.2		X
-synstructure@0.13.2										X
-time@0.3.41		X								X
-time-core@0.1.4		X								X
-time-macros@0.2.22		X								X
-tinystr@0.8.1											X
-tokio@1.47.1										X
-tokio-macros@2.5.0										X
-tokio-rustls@0.26.2		X								X
-tokio-util@0.7.15										X
-tower@0.5.2										X
-tower-http@0.6.6										X
-tower-layer@0.3.3										X
-tower-service@0.3.3										X
-tracing@0.1.41										X
-tracing-core@0.1.34										X
-try-lock@0.2.5										X
-typenum@1.18.0		X								X
-unicode-ident@1.0.18		X								X	X
-untrusted@0.9.0								X
-url@2.5.4		X								X
-utf8_iter@1.0.4		X								X
-uuid@1.17.0		X								X
-version_check@0.9.5		X								X
-want@0.3.1										X
-wasi@0.11.1+wasi-snapshot-preview1		X	X							X
-wasi@0.14.2+wasi-0.2.4		X	X							X
-wasm-bindgen@0.2.100		X								X
-wasm-bindgen-backend@0.2.100		X								X
-wasm-bindgen-futures@0.4.50		X								X
-wasm-bindgen-macro@0.2.100		X								X
-wasm-bindgen-macro-support@0.2.100		X								X
-wasm-bindgen-shared@0.2.100		X								X
-wasm-streams@0.4.2		X								X
-web-sys@0.3.77		X								X
-webpki-roots@1.0.1							X
-widestring@1.2.0		X								X
-windows@0.58.0		X								X
-windows-core@0.58.0		X								X
-windows-core@0.61.2		X								X
-windows-implement@0.58.0		X								X
-windows-implement@0.60.0		X								X
-windows-interface@0.58.0		X								X
-windows-interface@0.59.1		X								X
-windows-link@0.1.3		X								X
-windows-result@0.2.0		X								X
-windows-result@0.3.4		X								X
-windows-strings@0.1.0		X								X
-windows-strings@0.4.2		X								X
-windows-sys@0.52.0		X								X
-windows-sys@0.59.0		X								X
-windows-targets@0.52.6		X								X
-windows_aarch64_gnullvm@0.52.6		X								X
-windows_aarch64_msvc@0.52.6		X								X
-windows_i686_gnu@0.52.6		X								X
-windows_i686_gnullvm@0.52.6		X								X
-windows_i686_msvc@0.52.6		X								X
-windows_x86_64_gnu@0.52.6		X								X
-windows_x86_64_gnullvm@0.52.6		X								X
-windows_x86_64_msvc@0.52.6		X								X
-wit-bindgen-rt@0.39.0		X	X							X
-writeable@0.6.1											X
-yoke@0.8.0											X
-yoke-derive@0.8.0											X
-zerocopy@0.8.26		X		X						X
-zerofrom@0.1.6											X
-zerofrom-derive@0.1.6											X
-zeroize@1.8.1		X								X
-zerotrie@0.2.2											X
-zerovec@0.11.2											X
-zerovec-derive@0.11.1											X
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense
+android_system_properties@0.1.5	X								X		
+anyhow@1.0.100	X								X		
+async-trait@0.1.89	X								X		
+atomic-waker@1.1.2	X								X		
+autocfg@1.5.0	X								X		
+backon@1.6.0	X										
+base64@0.22.1	X								X		
+bincode@1.3.3									X		
+bitflags@2.10.0	X								X		
+block-buffer@0.10.4	X								X		
+bumpalo@3.19.1	X								X		
+bytes@1.11.0									X		
+cc@1.2.51	X								X		
+cfg-if@1.0.4	X								X		
+chrono@0.4.42	X								X		
+cloud-filter@0.0.6									X		
+cloud_filter_opendal@0.0.12	X										
+const-oid@0.9.6	X								X		
+core-foundation-sys@0.8.7	X								X		
+cpufeatures@0.2.17	X								X		
+crc32c@0.6.8	X								X		
+crypto-common@0.1.7	X								X		
+deranged@0.5.5	X								X		
+digest@0.10.7	X								X		
+displaydoc@0.2.5	X								X		
+dotenvy@0.15.7									X		
+errno@0.3.14	X								X		
+fastrand@2.3.0	X								X		
+find-msvc-tools@0.1.6	X								X		
+flagset@0.4.7	X										
+form_urlencoded@1.2.2	X								X		
+futures@0.3.31	X								X		
+futures-channel@0.3.31	X								X		
+futures-core@0.3.31	X								X		
+futures-executor@0.3.31	X								X		
+futures-io@0.3.31	X								X		
+futures-macro@0.3.31	X								X		
+futures-sink@0.3.31	X								X		
+futures-task@0.3.31	X								X		
+futures-util@0.3.31	X								X		
+generic-array@0.14.7									X		
+getrandom@0.2.16	X								X		
+getrandom@0.3.4	X								X		
+gloo-timers@0.3.0	X								X		
+hex@0.4.3	X								X		
+hmac@0.12.1	X								X		
+home@0.5.11	X								X		
+http@1.4.0	X								X		
+http-body@1.0.1									X		
+http-body-util@0.1.3									X		
+httparse@1.10.1	X								X		
+hyper@1.8.1									X		
+hyper-rustls@0.27.7	X						X		X		
+hyper-util@0.1.19									X		
+iana-time-zone@0.1.64	X								X		
+iana-time-zone-haiku@0.1.2	X								X		
+icu_collections@2.1.1										X	
+icu_locale_core@2.1.1										X	
+icu_normalizer@2.1.1										X	
+icu_normalizer_data@2.1.1										X	
+icu_properties@2.1.2										X	
+icu_properties_data@2.1.2										X	
+icu_provider@2.1.1										X	
+idna@1.1.0	X								X		
+idna_adapter@1.2.1	X								X		
+ipnet@2.11.0	X								X		
+iri-string@0.7.10	X								X		
+itoa@1.0.17	X								X		
+jiff@0.2.18									X		X
+jiff-tzdb@0.1.5									X		X
+jiff-tzdb-platform@0.1.3									X		X
+js-sys@0.3.83	X								X		
+libc@0.2.180	X								X		
+litemap@0.8.1										X	
+log@0.4.29	X								X		
+md-5@0.10.6	X								X		
+memchr@2.7.6									X		X
+memoffset@0.9.1									X		
+mio@1.1.1									X		
+nt-time@0.8.1	X								X		
+num-conv@0.1.0	X								X		
+num-traits@0.2.19	X								X		
+once_cell@1.21.3	X								X		
+opendal@0.55.0	X										
+percent-encoding@2.3.2	X								X		
+pin-project-lite@0.2.16	X								X		
+pin-utils@0.1.0	X								X		
+portable-atomic@1.13.0	X								X		
+portable-atomic-util@0.2.4	X								X		
+potential_utf@0.1.4										X	
+powerfmt@0.2.0	X								X		
+ppv-lite86@0.2.21	X								X		
+proc-macro2@1.0.105	X								X		
+quick-xml@0.37.5									X		
+quick-xml@0.38.4									X		
+quote@1.0.43	X								X		
+r-efi@5.3.0	X							X	X		
+rand@0.8.5	X								X		
+rand_chacha@0.3.1	X								X		
+rand_core@0.6.4	X								X		
+reqsign@0.16.5	X										
+reqwest@0.12.28	X								X		
+ring@0.17.14	X						X				
+rustc_version@0.4.1	X								X		
+rustls@0.23.36	X						X		X		
+rustls-pki-types@1.13.2	X								X		
+rustls-webpki@0.103.8							X				
+rustversion@1.0.22	X								X		
+ryu@1.0.22	X				X						
+semver@1.0.27	X								X		
+serde@1.0.228	X								X		
+serde_core@1.0.228	X								X		
+serde_derive@1.0.228	X								X		
+serde_json@1.0.149	X								X		
+serde_urlencoded@0.7.1	X								X		
+sha1@0.10.6	X								X		
+sha2@0.10.9	X								X		
+shlex@1.3.0	X								X		
+signal-hook-registry@1.4.8	X								X		
+slab@0.4.11									X		
+smallvec@1.15.1	X								X		
+socket2@0.6.1	X								X		
+stable_deref_trait@1.2.1	X								X		
+subtle@2.6.1				X							
+syn@2.0.114	X								X		
+sync_wrapper@1.0.2	X										
+synstructure@0.13.2									X		
+time@0.3.44	X								X		
+time-core@0.1.6	X								X		
+time-macros@0.2.24	X								X		
+tinystr@0.8.2										X	
+tokio@1.49.0									X		
+tokio-macros@2.6.0									X		
+tokio-rustls@0.26.4	X								X		
+tokio-util@0.7.18									X		
+tower@0.5.2									X		
+tower-http@0.6.8									X		
+tower-layer@0.3.3									X		
+tower-service@0.3.3									X		
+tracing@0.1.44									X		
+tracing-core@0.1.36									X		
+try-lock@0.2.5									X		
+typenum@1.19.0	X								X		
+unicode-ident@1.0.22	X								X	X	
+untrusted@0.9.0							X				
+url@2.5.8	X								X		
+utf8_iter@1.0.4	X								X		
+uuid@1.19.0	X								X		
+version_check@0.9.5	X								X		
+want@0.3.1									X		
+wasi@0.11.1+wasi-snapshot-preview1	X	X							X		
+wasip2@1.0.1+wasi-0.2.4	X	X							X		
+wasm-bindgen@0.2.106	X								X		
+wasm-bindgen-futures@0.4.56	X								X		
+wasm-bindgen-macro@0.2.106	X								X		
+wasm-bindgen-macro-support@0.2.106	X								X		
+wasm-bindgen-shared@0.2.106	X								X		
+wasm-streams@0.4.2	X								X		
+web-sys@0.3.83	X								X		
+webpki-roots@1.0.5						X					
+widestring@1.2.1	X								X		
+windows@0.58.0	X								X		
+windows-core@0.58.0	X								X		
+windows-core@0.62.2	X								X		
+windows-implement@0.58.0	X								X		
+windows-implement@0.60.2	X								X		
+windows-interface@0.58.0	X								X		
+windows-interface@0.59.3	X								X		
+windows-link@0.2.1	X								X		
+windows-result@0.2.0	X								X		
+windows-result@0.4.1	X								X		
+windows-strings@0.1.0	X								X		
+windows-strings@0.5.1	X								X		
+windows-sys@0.52.0	X								X		
+windows-sys@0.59.0	X								X		
+windows-sys@0.60.2	X								X		
+windows-sys@0.61.2	X								X		
+windows-targets@0.52.6	X								X		
+windows-targets@0.53.5	X								X		
+windows_aarch64_gnullvm@0.52.6	X								X		
+windows_aarch64_gnullvm@0.53.1	X								X		
+windows_aarch64_msvc@0.52.6	X								X		
+windows_aarch64_msvc@0.53.1	X								X		
+windows_i686_gnu@0.52.6	X								X		
+windows_i686_gnu@0.53.1	X								X		
+windows_i686_gnullvm@0.52.6	X								X		
+windows_i686_gnullvm@0.53.1	X								X		
+windows_i686_msvc@0.52.6	X								X		
+windows_i686_msvc@0.53.1	X								X		
+windows_x86_64_gnu@0.52.6	X								X		
+windows_x86_64_gnu@0.53.1	X								X		
+windows_x86_64_gnullvm@0.52.6	X								X		
+windows_x86_64_gnullvm@0.53.1	X								X		
+windows_x86_64_msvc@0.52.6	X								X		
+windows_x86_64_msvc@0.53.1	X								X		
+wit-bindgen@0.46.0	X	X							X		
+writeable@0.6.2										X	
+yoke@0.8.1										X	
+yoke-derive@0.8.1										X	
+zerocopy@0.8.33	X		X						X		
+zerofrom@0.1.6										X	
+zerofrom-derive@0.1.6										X	
+zeroize@1.8.2	X								X		
+zerotrie@0.2.3										X	
+zerovec@0.11.5										X	
+zerovec-derive@0.11.2										X	
+zmij@1.0.12									X		

--- a/integrations/fuse3/DEPENDENCIES.rust.tsv
+++ b/integrations/fuse3/DEPENDENCIES.rust.tsv
@@ -1,192 +1,179 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-addr2line@0.24.2		X							X			
-adler2@2.0.1	X	X							X			
-android-tzdata@0.1.1		X							X			
-android_system_properties@0.1.5		X							X			
-anyhow@1.0.98		X							X			
-async-notify@0.3.0									X			
-autocfg@1.5.0		X							X			
-backon@1.5.1		X										
-backtrace@0.3.75		X							X			
-base64@0.22.1		X							X			
-bincode@1.3.3									X			
-bitflags@2.9.1		X							X			
-block-buffer@0.10.4		X							X			
-bumpalo@3.19.0		X							X			
-bytes@1.10.1									X			
-cc@1.2.29		X							X			
-cfg-if@1.0.1		X							X			
-cfg_aliases@0.2.1									X			
-chrono@0.4.41		X							X			
-concurrent-queue@2.5.0		X							X			
-core-foundation-sys@0.8.7		X							X			
-crossbeam-utils@0.8.21		X							X			
-crypto-common@0.1.6		X							X			
-digest@0.10.7		X							X			
-displaydoc@0.2.5		X							X			
-either@1.15.0		X							X			
-errno@0.3.13		X							X			
-event-listener@4.0.3		X							X			
-fastrand@2.3.0		X							X			
-fnv@1.0.7		X							X			
-form_urlencoded@1.2.1		X							X			
-fuse3@0.8.1									X			
-fuse3_opendal@0.0.19		X										
-futures@0.3.31		X							X			
-futures-channel@0.3.31		X							X			
-futures-core@0.3.31		X							X			
-futures-io@0.3.31		X							X			
-futures-macro@0.3.31		X							X			
-futures-sink@0.3.31		X							X			
-futures-task@0.3.31		X							X			
-futures-util@0.3.31		X							X			
-generic-array@0.14.7									X			
-getrandom@0.2.16		X							X			
-getrandom@0.3.3		X							X			
-gimli@0.31.1		X							X			
-gloo-timers@0.3.0		X							X			
-home@0.5.11		X							X			
-http@1.3.1		X							X			
-http-body@1.0.1									X			
-http-body-util@0.1.3									X			
-httparse@1.10.1		X							X			
-hyper@1.6.0									X			
-hyper-rustls@0.27.7		X					X		X			
-hyper-util@0.1.15									X			
-iana-time-zone@0.1.63		X							X			
-iana-time-zone-haiku@0.1.2		X							X			
-icu_collections@2.0.0										X		
-icu_locale_core@2.0.0										X		
-icu_normalizer@2.0.0										X		
-icu_normalizer_data@2.0.0										X		
-icu_properties@2.0.1										X		
-icu_properties_data@2.0.1										X		
-icu_provider@2.0.0										X		
-idna@1.0.3		X							X			
-idna_adapter@1.2.1		X							X			
-io-uring@0.7.8		X							X			
-ipnet@2.11.0		X							X			
-iri-string@0.7.8		X							X			
-itoa@1.0.15		X							X			
-js-sys@0.3.77		X							X			
-lazy_static@1.5.0		X							X			
-libc@0.2.174		X							X			
-linux-raw-sys@0.4.15		X	X						X			
-litemap@0.8.0										X		
-log@0.4.27		X							X			
-md-5@0.10.6		X							X			
-memchr@2.7.5									X		X	
-memoffset@0.9.1									X			
-miniz_oxide@0.8.9		X							X			X
-mio@1.0.4									X			
-nix@0.29.0									X			
-num-traits@0.2.19		X							X			
-object@0.36.7		X							X			
-once_cell@1.21.3		X							X			
-opendal@0.54.1		X										
-parking@2.2.1		X							X			
-percent-encoding@2.3.1		X							X			
-pin-project-lite@0.2.16		X							X			
-pin-utils@0.1.0		X							X			
-potential_utf@0.1.2										X		
-proc-macro2@1.0.95		X							X			
-quick-xml@0.38.3									X			
-quote@1.0.40		X							X			
-r-efi@5.3.0		X						X	X			
-reqwest@0.12.22		X							X			
-ring@0.17.14		X					X					
-rustc-demangle@0.1.25		X							X			
-rustix@0.38.44		X	X						X			
-rustls@0.23.29		X					X		X			
-rustls-pki-types@1.12.0		X							X			
-rustls-webpki@0.103.4							X					
-rustversion@1.0.21		X							X			
-ryu@1.0.20		X			X							
-serde@1.0.219		X							X			
-serde_derive@1.0.219		X							X			
-serde_json@1.0.140		X							X			
-serde_urlencoded@0.7.1		X							X			
-sharded-slab@0.1.7									X			
-shlex@1.3.0		X							X			
-signal-hook-registry@1.4.5		X							X			
-slab@0.4.10									X			
-smallvec@1.15.1		X							X			
-socket2@0.5.10		X							X			
-socket2@0.6.0		X							X			
-stable_deref_trait@1.2.0		X							X			
-subtle@2.6.1				X								
-syn@2.0.104		X							X			
-sync_wrapper@1.0.2		X										
-synstructure@0.13.2									X			
-tinystr@0.8.1										X		
-tokio@1.47.1									X			
-tokio-macros@2.5.0									X			
-tokio-rustls@0.26.2		X							X			
-tokio-util@0.7.15									X			
-tower@0.5.2									X			
-tower-http@0.6.6									X			
-tower-layer@0.3.3									X			
-tower-service@0.3.3									X			
-tracing@0.1.41									X			
-tracing-attributes@0.1.30									X			
-tracing-core@0.1.34									X			
-trait-make@0.1.0		X							X			
-try-lock@0.2.5									X			
-typenum@1.18.0		X							X			
-unicode-ident@1.0.18		X							X	X		
-untrusted@0.9.0							X					
-url@2.5.4		X							X			
-utf8_iter@1.0.4		X							X			
-uuid@1.17.0		X							X			
-version_check@0.9.5		X							X			
-want@0.3.1									X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X						X			
-wasi@0.14.2+wasi-0.2.4		X	X						X			
-wasm-bindgen@0.2.100		X							X			
-wasm-bindgen-backend@0.2.100		X							X			
-wasm-bindgen-futures@0.4.50		X							X			
-wasm-bindgen-macro@0.2.100		X							X			
-wasm-bindgen-macro-support@0.2.100		X							X			
-wasm-bindgen-shared@0.2.100		X							X			
-wasm-streams@0.4.2		X							X			
-web-sys@0.3.77		X							X			
-webpki-roots@1.0.1						X						
-which@6.0.3									X			
-windows-core@0.61.2		X							X			
-windows-implement@0.60.0		X							X			
-windows-interface@0.59.1		X							X			
-windows-link@0.1.3		X							X			
-windows-result@0.3.4		X							X			
-windows-strings@0.4.2		X							X			
-windows-sys@0.52.0		X							X			
-windows-sys@0.59.0		X							X			
-windows-sys@0.60.2		X							X			
-windows-targets@0.52.6		X							X			
-windows-targets@0.53.2		X							X			
-windows_aarch64_gnullvm@0.52.6		X							X			
-windows_aarch64_gnullvm@0.53.0		X							X			
-windows_aarch64_msvc@0.52.6		X							X			
-windows_aarch64_msvc@0.53.0		X							X			
-windows_i686_gnu@0.52.6		X							X			
-windows_i686_gnu@0.53.0		X							X			
-windows_i686_gnullvm@0.52.6		X							X			
-windows_i686_gnullvm@0.53.0		X							X			
-windows_i686_msvc@0.52.6		X							X			
-windows_i686_msvc@0.53.0		X							X			
-windows_x86_64_gnu@0.52.6		X							X			
-windows_x86_64_gnu@0.53.0		X							X			
-windows_x86_64_gnullvm@0.52.6		X							X			
-windows_x86_64_gnullvm@0.53.0		X							X			
-windows_x86_64_msvc@0.52.6		X							X			
-windows_x86_64_msvc@0.53.0		X							X			
-winsafe@0.0.19									X			
-wit-bindgen-rt@0.39.0		X	X						X			
-writeable@0.6.1										X		
-yoke@0.8.0										X		
-yoke-derive@0.8.0										X		
-zerofrom@0.1.6										X		
-zerofrom-derive@0.1.6										X		
-zeroize@1.8.1		X							X			
-zerotrie@0.2.2										X		
-zerovec@0.11.2										X		
-zerovec-derive@0.11.1										X		
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense
+anyhow@1.0.100	X							X		
+async-notify@0.3.2								X		
+atomic-waker@1.1.2	X							X		
+autocfg@1.5.0	X							X		
+backon@1.6.0	X									
+base64@0.22.1	X							X		
+bincode@1.3.3								X		
+bitflags@2.10.0	X							X		
+block-buffer@0.10.4	X							X		
+bumpalo@3.19.1	X							X		
+bytes@1.11.0								X		
+cc@1.2.51	X							X		
+cfg-if@1.0.4	X							X		
+cfg_aliases@0.2.1								X		
+concurrent-queue@2.5.0	X							X		
+crossbeam-utils@0.8.21	X							X		
+crypto-common@0.1.7	X							X		
+digest@0.10.7	X							X		
+displaydoc@0.2.5	X							X		
+either@1.15.0	X							X		
+errno@0.3.14	X							X		
+event-listener@5.4.1	X							X		
+fastrand@2.3.0	X							X		
+find-msvc-tools@0.1.6	X							X		
+form_urlencoded@1.2.2	X							X		
+fuse3@0.8.1								X		
+fuse3_opendal@0.0.19	X									
+futures@0.3.31	X							X		
+futures-channel@0.3.31	X							X		
+futures-core@0.3.31	X							X		
+futures-io@0.3.31	X							X		
+futures-macro@0.3.31	X							X		
+futures-sink@0.3.31	X							X		
+futures-task@0.3.31	X							X		
+futures-util@0.3.31	X							X		
+generic-array@0.14.7								X		
+getrandom@0.2.16	X							X		
+getrandom@0.3.4	X							X		
+gloo-timers@0.3.0	X							X		
+home@0.5.11	X							X		
+http@1.4.0	X							X		
+http-body@1.0.1								X		
+http-body-util@0.1.3								X		
+httparse@1.10.1	X							X		
+hyper@1.8.1								X		
+hyper-rustls@0.27.7	X					X		X		
+hyper-util@0.1.19								X		
+icu_collections@2.1.1									X	
+icu_locale_core@2.1.1									X	
+icu_normalizer@2.1.1									X	
+icu_normalizer_data@2.1.1									X	
+icu_properties@2.1.2									X	
+icu_properties_data@2.1.2									X	
+icu_provider@2.1.1									X	
+idna@1.1.0	X							X		
+idna_adapter@1.2.1	X							X		
+ipnet@2.11.0	X							X		
+iri-string@0.7.10	X							X		
+itoa@1.0.17	X							X		
+jiff@0.2.18								X		X
+jiff-tzdb@0.1.5								X		X
+jiff-tzdb-platform@0.1.3								X		X
+js-sys@0.3.83	X							X		
+lazy_static@1.5.0	X							X		
+libc@0.2.180	X							X		
+linux-raw-sys@0.4.15	X	X						X		
+litemap@0.8.1									X	
+log@0.4.29	X							X		
+md-5@0.10.6	X							X		
+memchr@2.7.6								X		X
+memoffset@0.9.1								X		
+mio@1.1.1								X		
+nix@0.29.0								X		
+once_cell@1.21.3	X							X		
+opendal@0.55.0	X									
+parking@2.2.1	X							X		
+percent-encoding@2.3.2	X							X		
+pin-project-lite@0.2.16	X							X		
+pin-utils@0.1.0	X							X		
+portable-atomic@1.13.0	X							X		
+portable-atomic-util@0.2.4	X							X		
+potential_utf@0.1.4									X	
+proc-macro2@1.0.105	X							X		
+quick-xml@0.38.4								X		
+quote@1.0.43	X							X		
+r-efi@5.3.0	X						X	X		
+reqwest@0.12.28	X							X		
+ring@0.17.14	X					X				
+rustix@0.38.44	X	X						X		
+rustls@0.23.36	X					X		X		
+rustls-pki-types@1.13.2	X							X		
+rustls-webpki@0.103.8						X				
+rustversion@1.0.22	X							X		
+ryu@1.0.22	X			X						
+serde@1.0.228	X							X		
+serde_core@1.0.228	X							X		
+serde_derive@1.0.228	X							X		
+serde_json@1.0.149	X							X		
+serde_urlencoded@0.7.1	X							X		
+sharded-slab@0.1.7								X		
+shlex@1.3.0	X							X		
+signal-hook-registry@1.4.8	X							X		
+slab@0.4.11								X		
+smallvec@1.15.1	X							X		
+socket2@0.6.1	X							X		
+stable_deref_trait@1.2.1	X							X		
+subtle@2.6.1			X							
+syn@2.0.114	X							X		
+sync_wrapper@1.0.2	X									
+synstructure@0.13.2								X		
+tinystr@0.8.2									X	
+tokio@1.49.0								X		
+tokio-macros@2.6.0								X		
+tokio-rustls@0.26.4	X							X		
+tokio-util@0.7.18								X		
+tower@0.5.2								X		
+tower-http@0.6.8								X		
+tower-layer@0.3.3								X		
+tower-service@0.3.3								X		
+tracing@0.1.44								X		
+tracing-attributes@0.1.31								X		
+tracing-core@0.1.36								X		
+trait-make@0.1.0	X							X		
+try-lock@0.2.5								X		
+typenum@1.19.0	X							X		
+unicode-ident@1.0.22	X							X	X	
+untrusted@0.9.0						X				
+url@2.5.8	X							X		
+utf8_iter@1.0.4	X							X		
+uuid@1.19.0	X							X		
+version_check@0.9.5	X							X		
+want@0.3.1								X		
+wasi@0.11.1+wasi-snapshot-preview1	X	X						X		
+wasip2@1.0.1+wasi-0.2.4	X	X						X		
+wasm-bindgen@0.2.106	X							X		
+wasm-bindgen-futures@0.4.56	X							X		
+wasm-bindgen-macro@0.2.106	X							X		
+wasm-bindgen-macro-support@0.2.106	X							X		
+wasm-bindgen-shared@0.2.106	X							X		
+wasm-streams@0.4.2	X							X		
+web-sys@0.3.83	X							X		
+webpki-roots@1.0.5					X					
+which@6.0.3								X		
+windows-link@0.2.1	X							X		
+windows-sys@0.52.0	X							X		
+windows-sys@0.59.0	X							X		
+windows-sys@0.60.2	X							X		
+windows-sys@0.61.2	X							X		
+windows-targets@0.52.6	X							X		
+windows-targets@0.53.5	X							X		
+windows_aarch64_gnullvm@0.52.6	X							X		
+windows_aarch64_gnullvm@0.53.1	X							X		
+windows_aarch64_msvc@0.52.6	X							X		
+windows_aarch64_msvc@0.53.1	X							X		
+windows_i686_gnu@0.52.6	X							X		
+windows_i686_gnu@0.53.1	X							X		
+windows_i686_gnullvm@0.52.6	X							X		
+windows_i686_gnullvm@0.53.1	X							X		
+windows_i686_msvc@0.52.6	X							X		
+windows_i686_msvc@0.53.1	X							X		
+windows_x86_64_gnu@0.52.6	X							X		
+windows_x86_64_gnu@0.53.1	X							X		
+windows_x86_64_gnullvm@0.52.6	X							X		
+windows_x86_64_gnullvm@0.53.1	X							X		
+windows_x86_64_msvc@0.52.6	X							X		
+windows_x86_64_msvc@0.53.1	X							X		
+winsafe@0.0.19								X		
+wit-bindgen@0.46.0	X	X						X		
+writeable@0.6.2									X	
+yoke@0.8.1									X	
+yoke-derive@0.8.1									X	
+zerofrom@0.1.6									X	
+zerofrom-derive@0.1.6									X	
+zeroize@1.8.2	X							X		
+zerotrie@0.2.3									X	
+zerovec@0.11.5									X	
+zerovec-derive@0.11.2									X	
+zmij@1.0.12								X		

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,26 +16,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-[package]
-description = "fuse3 integration for Apache OpenDAL"
-name = "fuse3_opendal"
+from pathlib import Path
 
-authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
-edition = "2024"
-homepage = "https://opendal.apache.org/"
-license = "Apache-2.0"
-repository = "https://github.com/apache/opendal"
-rust-version = "1.85"
-version = "0.0.19"
-
-[dependencies]
-bytes = "1.6.0"
-fuse3 = { version = "0.8.1", "features" = ["tokio-runtime", "unprivileged"] }
-futures-util = "0.3.30"
-libc = "0.2.155"
-log = "0.4.21"
-opendal = { version = "0.55.0" }
-sharded-slab = "0.1.7"
-tokio = "1.38.0"
-
-[dev-dependencies]
+ROOT_DIR = Path(__file__).resolve().parent.parent
+PACKAGES = [
+    ".",
+    "integrations/fuse3",
+    "integrations/cloud_filter",
+]

--- a/scripts/dependencies.py
+++ b/scripts/dependencies.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+from pathlib import Path
+import subprocess
+
+from constants import PACKAGES, ROOT_DIR
+
+
+def package_paths():
+    for package in PACKAGES:
+        yield (ROOT_DIR / package).resolve()
+
+
+def check_single_package(package_dir: Path):
+    if (package_dir / "Cargo.toml").exists():
+        print(f"Checking dependencies of {package_dir}")
+        subprocess.run(["cargo", "deny", "check", "license"], cwd=package_dir)
+    else:
+        print(f"Skipping {package_dir} as Cargo.toml does not exist")
+
+
+def check_deps():
+    for package_dir in package_paths():
+        check_single_package(package_dir)
+
+
+def generate_single_package(package_dir: Path):
+    if (package_dir / "Cargo.toml").exists():
+        print(f"Generating dependencies {package_dir}")
+        result = subprocess.check_output(
+            ["cargo", "deny", "list", "-f", "tsv", "-t", "0.6"],
+            cwd=package_dir,
+            text=True,
+        )
+        output_path = package_dir / "DEPENDENCIES.rust.tsv"
+        output_path.write_text(result)
+    else:
+        print(f"Skipping {package_dir} as Cargo.toml does not exist")
+
+
+def generate_deps():
+    for package_dir in package_paths():
+        generate_single_package(package_dir)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
+    parser.set_defaults(func=parser.print_help)
+    subparsers = parser.add_subparsers()
+
+    parser_check = subparsers.add_parser(
+        "check", description="Check dependencies", help="Check dependencies"
+    )
+    parser_check.set_defaults(func=check_deps)
+
+    parser_generate = subparsers.add_parser(
+        "generate", description="Generate dependencies", help="Generate dependencies"
+    )
+    parser_generate.set_defaults(func=generate_deps)
+
+    args = parser.parse_args()
+    arg_dict = dict(vars(args))
+    del arg_dict["func"]
+    args.func(**arg_dict)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,10 +17,10 @@
 
 use std::sync::OnceLock;
 
-use opendal::raw::tests;
-use opendal::services;
 use opendal::Capability;
 use opendal::Operator;
+use opendal::raw::tests;
+use opendal::services;
 use tempfile::TempDir;
 use test_context::TestContext;
 use tokio::runtime::Runtime;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Sync ofs and integrations to opendal 0.55.0 and align dependency tooling with opendal scripts layout, including dependabot config.

# What changes are included in this PR?

- Bump opendal to 0.55.0 across ofs and integrations, update locks and DEPENDENCIES.
- Move dependency tooling to scripts/ and add simplified dependabot config.
- Apply rustfmt ordering changes.

# Are there any user-facing changes?

No.
