### PR TITLE
ci: enforce ASF Actions policy and fix FUSE write finalization

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -46,7 +46,7 @@ runs:
 
     - name: Setup Protoc
       if: inputs.need-protoc == 'true'
-      uses: arduino/setup-protoc@v3
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
         version: "23.4"
         repo-token: ${{ inputs.github-token }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,29 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Ofs CI
-
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
-
-jobs:
-  check_clippy_and_test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup
-      - name: Cargo clippy && test
-        run: |
-          cargo clippy --all-targets --all-features -- -D warnings
-          cargo test --all-targets --all-features
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: "semiannually"
+    groups:
+      github-actions:
+        patterns:
+          - "actions/*"
+      third-party-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/asf_allowlist_check.yml
+++ b/.github/workflows/asf_allowlist_check.yml
@@ -15,29 +15,36 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Ofs CI
+name: ASF Allowlist Check
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
   pull_request:
     branches:
       - main
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
-  check_clippy_and_test:
+  asf-allowlist-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup
-      - name: Cargo clippy && test
-        run: |
-          cargo clippy --all-targets --all-features -- -D warnings
-          cargo test --all-targets --all-features
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: apache/infrastructure-actions/allowlist-check@main
+        with:
+          scan-glob: ".github/**/*.y*ml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,11 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            build-command: cargo
             use-cross: false
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+            build-command: cross
             use-cross: true
     steps:
       - uses: actions/checkout@v5
@@ -53,14 +55,15 @@ jobs:
       - name: Setup Rust builder
         uses: ./.github/actions/setup
 
+      - name: Install cross
+        if: matrix.use-cross
+        run: cargo install cross --locked
+
       - name: Build target
-        uses: ClementTsang/cargo-action@v0.0.7
-        with:
-          use-cross: ${{ !!matrix.use-cross }}
-          command: build
-          args: --locked --release --target ${{ matrix.target }}
         env:
+          BUILD_COMMAND: ${{ matrix.build-command }}
           CARGO_PROFILE_RELEASE_LTO: true
+        run: '"${BUILD_COMMAND}" build --locked --release --target "${{ matrix.target }}"'
 
       - name: Package artifact (Unix)
         if: runner.os != 'Windows'
@@ -99,7 +102,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             dist/*.tar.gz

--- a/integrations/fuse3/src/file_system.rs
+++ b/integrations/fuse3/src/file_system.rs
@@ -156,6 +156,15 @@ impl Filesystem {
 
         Ok(file)
     }
+
+    async fn finish_opened_file(file: OpenedFile) -> Result<()> {
+        if let Some(inner_writer) = file.inner_writer {
+            let mut inner = inner_writer.lock().await;
+            inner.writer.close().await.map_err(opendal_error2errno)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl PathFilesystem for Filesystem {
@@ -482,15 +491,15 @@ impl PathFilesystem for Filesystem {
             "release(path={path:?}, fh={fh}, flags=0x{flags:x}, lock_owner={lock_owner}, flush={flush})"
         );
 
-        // Just take and forget it.
-        let _ = self.opened_files.take(FileKey::try_from(fh)?.0);
-        Ok(())
+        let Some(file) = self.opened_files.take(FileKey::try_from(fh)?.0) else {
+            return Ok(());
+        };
+
+        Self::finish_opened_file(file).await
     }
 
-    /// In design, flush could be called multiple times for a single open. But there is the only
-    /// place that we can handle the write operations.
-    ///
-    /// So we only support the use case that flush only be called once.
+    /// FUSE can call flush multiple times or omit it. The first flush finalizes the writer, while
+    /// release provides the fallback when flush is omitted.
     async fn flush(
         &self,
         _req: Request,
@@ -500,18 +509,14 @@ impl PathFilesystem for Filesystem {
     ) -> Result<()> {
         log::debug!("flush(path={path:?}, fh={fh}, lock_owner={lock_owner})");
 
-        let file = self
-            .opened_files
-            .take(FileKey::try_from(fh)?.0)
-            .ok_or(Errno::from(libc::EBADF))?;
+        let Some(file) = self.opened_files.take(FileKey::try_from(fh)?.0) else {
+            return Ok(());
+        };
 
-        if let Some(inner_writer) = file.inner_writer {
-            let mut lock = inner_writer.lock().await;
-            let res = lock.writer.close().await.map_err(opendal_error2errno);
-            return res.map(|_| ());
-        }
+        let path_mismatch = matches!(path, Some(path) if path != file.path);
+        Self::finish_opened_file(file).await?;
 
-        if matches!(path, Some(ref p) if p != &file.path) {
+        if path_mismatch {
             Err(Errno::from(libc::EBADF))?;
         }
 

--- a/tests/file_system.rs
+++ b/tests/file_system.rs
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
+
+use std::ffi::OsStr;
+
+use fuse3::path::prelude::*;
+use opendal::Operator;
+use opendal::services;
+
+#[tokio::test]
+async fn test_release_commits_pending_write() {
+    let root = tempfile::tempdir().unwrap();
+    let root_path = root.path().to_string_lossy().to_string();
+    let operator = Operator::new(services::Fs::default().root(&root_path))
+        .unwrap()
+        .finish();
+    let filesystem = fuse3_opendal::Filesystem::new(operator.clone(), 0, 0);
+
+    let path = OsStr::new("test.txt");
+    let flags = (libc::O_WRONLY | libc::O_TRUNC) as u32;
+    let created = filesystem
+        .create(Request::default(), OsStr::new(""), path, 0o644, flags)
+        .await
+        .unwrap();
+    filesystem
+        .write(
+            Request::default(),
+            Some(path),
+            created.fh,
+            0,
+            b"hello",
+            0,
+            flags,
+        )
+        .await
+        .unwrap();
+
+    filesystem
+        .release(Request::default(), Some(path), created.fh, flags, 0, false)
+        .await
+        .unwrap();
+
+    let content = operator.read("test.txt").await.unwrap().to_bytes();
+    assert_eq!(content.as_ref(), b"hello");
+}


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

ASF Infrastructure's allowlist check reported that the existing sccache and cargo wrapper actions were not approved. The sccache layer is unnecessary, and leaving non-allowlisted actions in the workflows can cause startup failures without useful job logs.

Once CI could run, the file tests exposed an existing FUSE write-finalization race. The integration only closed the OpenDAL writer from `flush`, even though FUSE may omit `flush` or call it multiple times. `release` could therefore discard a pending writer and leave a missing or empty file after close.

# What changes are included in this PR?

This adds the ASF allowlist check and GitHub Actions Dependabot coverage, removes sccache, replaces the unapproved cargo wrapper with direct cargo and cross commands, and pins the remaining third-party actions to commit SHAs.

It also finalizes each pending writer from either the first `flush` or `release` call and adds a direct regression test for the release-without-flush path.

# Are there any user-facing changes?

Yes. FUSE-backed writes are now committed when the final file handle is released even if `flush` is omitted.