### PR TITLE
fix(fuse): preserve handles across flush

### DIFF
--- a/integrations/fuse3/src/file.rs
+++ b/integrations/fuse3/src/file.rs
@@ -37,7 +37,7 @@ pub struct OpenedFile {
 ///
 /// We need better naming and API for this struct.
 pub struct InnerWriter {
-    pub writer: Writer,
+    pub writer: Option<Writer>,
     pub written: u64,
 }
 

--- a/integrations/fuse3/src/file_system.rs
+++ b/integrations/fuse3/src/file_system.rs
@@ -157,10 +157,12 @@ impl Filesystem {
         Ok(file)
     }
 
-    async fn finish_opened_file(file: OpenedFile) -> Result<()> {
-        if let Some(inner_writer) = file.inner_writer {
+    async fn finish_writer(inner_writer: Option<Arc<Mutex<InnerWriter>>>) -> Result<()> {
+        if let Some(inner_writer) = inner_writer {
             let mut inner = inner_writer.lock().await;
-            inner.writer.close().await.map_err(opendal_error2errno)?;
+            if let Some(mut writer) = inner.writer.take() {
+                writer.close().await.map_err(opendal_error2errno)?;
+            }
         }
 
         Ok(())
@@ -383,7 +385,10 @@ impl PathFilesystem for Filesystem {
             } else {
                 0
             };
-            Some(Arc::new(Mutex::new(InnerWriter { writer, written })))
+            Some(Arc::new(Mutex::new(InnerWriter {
+                writer: Some(writer),
+                written,
+            })))
         } else {
             None
         };
@@ -468,6 +473,8 @@ impl PathFilesystem for Filesystem {
 
         inner
             .writer
+            .as_mut()
+            .ok_or(Errno::from(libc::EBADF))?
             .write_from(data)
             .await
             .map_err(opendal_error2errno)?;
@@ -495,7 +502,7 @@ impl PathFilesystem for Filesystem {
             return Ok(());
         };
 
-        Self::finish_opened_file(file).await
+        Self::finish_writer(file.inner_writer).await
     }
 
     /// FUSE can call flush multiple times or omit it. The first flush finalizes the writer, while
@@ -509,17 +516,12 @@ impl PathFilesystem for Filesystem {
     ) -> Result<()> {
         log::debug!("flush(path={path:?}, fh={fh}, lock_owner={lock_owner})");
 
-        let Some(file) = self.opened_files.take(FileKey::try_from(fh)?.0) else {
-            return Ok(());
+        let inner_writer = {
+            let file = self.get_opened_file(FileKey::try_from(fh)?, path)?;
+            file.inner_writer.clone()
         };
 
-        let path_mismatch = matches!(path, Some(path) if path != file.path);
-        Self::finish_opened_file(file).await?;
-
-        if path_mismatch {
-            Err(Errno::from(libc::EBADF))?;
-        }
-
+        Self::finish_writer(inner_writer).await?;
         Ok(())
     }
 
@@ -613,7 +615,10 @@ impl PathFilesystem for Filesystem {
                 .append(is_append)
                 .await
                 .map_err(opendal_error2errno)?;
-            Some(Arc::new(Mutex::new(InnerWriter { writer, written: 0 })))
+            Some(Arc::new(Mutex::new(InnerWriter {
+                writer: Some(writer),
+                written: 0,
+            })))
         } else {
             None
         };

--- a/tests/file_system.rs
+++ b/tests/file_system.rs
@@ -59,3 +59,37 @@ async fn test_release_commits_pending_write() {
     let content = operator.read("test.txt").await.unwrap().to_bytes();
     assert_eq!(content.as_ref(), b"hello");
 }
+
+#[tokio::test]
+async fn test_flush_keeps_file_handle_open() {
+    let root = tempfile::tempdir().unwrap();
+    let root_path = root.path().to_string_lossy().to_string();
+    let operator = Operator::new(services::Fs::default().root(&root_path))
+        .unwrap()
+        .finish();
+    operator.write("test.txt", "hello").await.unwrap();
+
+    let filesystem = fuse3_opendal::Filesystem::new(operator, 0, 0);
+    let path = OsStr::new("test.txt");
+    let flags = libc::O_RDONLY as u32;
+    let opened = filesystem
+        .open(Request::default(), path, flags)
+        .await
+        .unwrap();
+
+    filesystem
+        .flush(Request::default(), Some(path), opened.fh, 0)
+        .await
+        .unwrap();
+
+    let reply = filesystem
+        .read(Request::default(), Some(path), opened.fh, 0, 5)
+        .await
+        .unwrap();
+    assert_eq!(reply.data.as_ref(), b"hello");
+
+    filesystem
+        .release(Request::default(), Some(path), opened.fh, flags, 0, false)
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

The FUSE `flush` implementation removes the open file entry from `opened_files`. However, FUSE may call `flush` multiple times for one `open`, while `release` is the terminal event for the file handle. Removing the entry during `flush` can make later operations on the same handle fail with `ENOENT`, which caused the file tests to fail intermittently in CI.

# What changes are included in this PR?

This keeps the open file entry alive across `flush` and removes it only during `release`. Writer finalization is made idempotent so both lifecycle callbacks can safely finalize pending data, and a regression test verifies that a handle remains readable after `flush` until `release`.

# Are there any user-facing changes?

Yes. FUSE file handles now remain valid through their documented lifecycle instead of becoming invalid after `flush`. There are no public API changes.

# Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- The new regression test failed with `Errno(2)` before the fix and passed afterward.

The local validation ran on macOS, where the Linux FUSE mount tests are not enabled. The GitHub Actions Linux run remains the final platform check.
