### PR TITLE
fix(fuse): bound reads to requested range

### DIFF
--- a/integrations/fuse3/src/file.rs
+++ b/integrations/fuse3/src/file.rs
@@ -30,6 +30,7 @@ use tokio::sync::Mutex;
 pub struct OpenedFile {
     pub path: OsString,
     pub is_read: bool,
+    pub content_length: u64,
     pub inner_writer: Option<Arc<Mutex<InnerWriter>>>,
 }
 

--- a/integrations/fuse3/src/file.rs
+++ b/integrations/fuse3/src/file.rs
@@ -30,7 +30,6 @@ use tokio::sync::Mutex;
 pub struct OpenedFile {
     pub path: OsString,
     pub is_read: bool,
-    pub content_length: u64,
     pub inner_writer: Option<Arc<Mutex<InnerWriter>>>,
 }
 

--- a/integrations/fuse3/src/file_system.rs
+++ b/integrations/fuse3/src/file_system.rs
@@ -369,6 +369,18 @@ impl PathFilesystem for Filesystem {
                 .map_err(opendal_error2errno)?;
         }
 
+        let content_length = if is_trunc {
+            0
+        } else if is_read || is_append {
+            self.op
+                .stat(&path.to_string_lossy())
+                .await
+                .map_err(opendal_error2errno)?
+                .content_length()
+        } else {
+            0
+        };
+
         let inner_writer = if is_trunc || is_append {
             let writer = self
                 .op
@@ -376,18 +388,9 @@ impl PathFilesystem for Filesystem {
                 .append(is_append)
                 .await
                 .map_err(opendal_error2errno)?;
-            let written = if is_append {
-                self.op
-                    .stat(&path.to_string_lossy())
-                    .await
-                    .map_err(opendal_error2errno)?
-                    .content_length()
-            } else {
-                0
-            };
             Some(Arc::new(Mutex::new(InnerWriter {
                 writer: Some(writer),
-                written,
+                written: if is_append { content_length } else { 0 },
             })))
         } else {
             None
@@ -398,6 +401,7 @@ impl PathFilesystem for Filesystem {
             .insert(OpenedFile {
                 path: path.into(),
                 is_read,
+                content_length,
                 inner_writer,
             })
             .ok_or(Errno::from(libc::EBUSY))?;
@@ -418,17 +422,22 @@ impl PathFilesystem for Filesystem {
     ) -> Result<ReplyData> {
         log::debug!("read(path={path:?}, fh={fh}, offset={offset}, size={size})");
 
-        let file_path = {
+        let (file_path, content_length) = {
             let file = self.get_opened_file(FileKey::try_from(fh)?, path)?;
             if !file.is_read {
                 Err(Errno::from(libc::EACCES))?;
             }
-            file.path.to_string_lossy().to_string()
+            (file.path.to_string_lossy().to_string(), file.content_length)
         };
 
         let end = offset
             .checked_add(u64::from(size))
-            .ok_or(Errno::from(libc::EOVERFLOW))?;
+            .ok_or(Errno::from(libc::EOVERFLOW))?
+            .min(content_length);
+
+        if offset >= end {
+            return Ok(ReplyData { data: Bytes::new() });
+        }
 
         let data = self
             .op
@@ -635,6 +644,7 @@ impl PathFilesystem for Filesystem {
             .insert(OpenedFile {
                 path: path.into(),
                 is_read,
+                content_length: 0,
                 inner_writer,
             })
             .ok_or(Errno::from(libc::EBUSY))?;

--- a/integrations/fuse3/src/file_system.rs
+++ b/integrations/fuse3/src/file_system.rs
@@ -369,18 +369,6 @@ impl PathFilesystem for Filesystem {
                 .map_err(opendal_error2errno)?;
         }
 
-        let content_length = if is_trunc {
-            0
-        } else if is_read || is_append {
-            self.op
-                .stat(&path.to_string_lossy())
-                .await
-                .map_err(opendal_error2errno)?
-                .content_length()
-        } else {
-            0
-        };
-
         let inner_writer = if is_trunc || is_append {
             let writer = self
                 .op
@@ -388,9 +376,18 @@ impl PathFilesystem for Filesystem {
                 .append(is_append)
                 .await
                 .map_err(opendal_error2errno)?;
+            let written = if is_append {
+                self.op
+                    .stat(&path.to_string_lossy())
+                    .await
+                    .map_err(opendal_error2errno)?
+                    .content_length()
+            } else {
+                0
+            };
             Some(Arc::new(Mutex::new(InnerWriter {
                 writer: Some(writer),
-                written: if is_append { content_length } else { 0 },
+                written,
             })))
         } else {
             None
@@ -401,7 +398,6 @@ impl PathFilesystem for Filesystem {
             .insert(OpenedFile {
                 path: path.into(),
                 is_read,
-                content_length,
                 inner_writer,
             })
             .ok_or(Errno::from(libc::EBUSY))?;
@@ -422,18 +418,24 @@ impl PathFilesystem for Filesystem {
     ) -> Result<ReplyData> {
         log::debug!("read(path={path:?}, fh={fh}, offset={offset}, size={size})");
 
-        let (file_path, content_length) = {
+        let file_path = {
             let file = self.get_opened_file(FileKey::try_from(fh)?, path)?;
             if !file.is_read {
                 Err(Errno::from(libc::EACCES))?;
             }
-            (file.path.to_string_lossy().to_string(), file.content_length)
+            file.path.to_string_lossy().to_string()
         };
 
         let end = offset
             .checked_add(u64::from(size))
-            .ok_or(Errno::from(libc::EOVERFLOW))?
-            .min(content_length);
+            .ok_or(Errno::from(libc::EOVERFLOW))?;
+        let content_length = self
+            .op
+            .stat(&file_path)
+            .await
+            .map_err(opendal_error2errno)?
+            .content_length();
+        let end = end.min(content_length);
 
         if offset >= end {
             return Ok(ReplyData { data: Bytes::new() });
@@ -644,7 +646,6 @@ impl PathFilesystem for Filesystem {
             .insert(OpenedFile {
                 path: path.into(),
                 is_read,
-                content_length: 0,
                 inner_writer,
             })
             .ok_or(Errno::from(libc::EBUSY))?;

--- a/integrations/fuse3/src/file_system.rs
+++ b/integrations/fuse3/src/file_system.rs
@@ -426,10 +426,14 @@ impl PathFilesystem for Filesystem {
             file.path.to_string_lossy().to_string()
         };
 
+        let end = offset
+            .checked_add(u64::from(size))
+            .ok_or(Errno::from(libc::EOVERFLOW))?;
+
         let data = self
             .op
             .read_with(&file_path)
-            .range(offset..)
+            .range(offset..end)
             .await
             .map_err(opendal_error2errno)?;
 

--- a/tests/file_system.rs
+++ b/tests/file_system.rs
@@ -93,3 +93,105 @@ async fn test_flush_keeps_file_handle_open() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn test_read_honors_requested_range() {
+    let root = tempfile::tempdir().unwrap();
+    let root_path = root.path().to_string_lossy().to_string();
+    let operator = Operator::new(services::Fs::default().root(&root_path))
+        .unwrap()
+        .finish();
+    operator.write("source.txt", "hello world").await.unwrap();
+
+    let filesystem = fuse3_opendal::Filesystem::new(operator, 0, 0);
+    let path = OsStr::new("source.txt");
+    let flags = libc::O_RDONLY as u32;
+    let opened = filesystem
+        .open(Request::default(), path, flags)
+        .await
+        .unwrap();
+
+    let reply = filesystem
+        .read(Request::default(), Some(path), opened.fh, 1, 4)
+        .await
+        .unwrap();
+    assert_eq!(reply.data.as_ref(), b"ello");
+
+    filesystem
+        .release(Request::default(), Some(path), opened.fh, flags, 0, false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_copy_file_range_honors_requested_length() {
+    let root = tempfile::tempdir().unwrap();
+    let root_path = root.path().to_string_lossy().to_string();
+    let operator = Operator::new(services::Fs::default().root(&root_path))
+        .unwrap()
+        .finish();
+    operator.write("source.txt", "hello world").await.unwrap();
+
+    let filesystem = fuse3_opendal::Filesystem::new(operator.clone(), 0, 0);
+    let source_path = OsStr::new("source.txt");
+    let source_flags = libc::O_RDONLY as u32;
+    let source = filesystem
+        .open(Request::default(), source_path, source_flags)
+        .await
+        .unwrap();
+
+    let target_path = OsStr::new("target.txt");
+    let target_flags = (libc::O_WRONLY | libc::O_TRUNC) as u32;
+    let target = filesystem
+        .create(
+            Request::default(),
+            OsStr::new(""),
+            target_path,
+            0o644,
+            target_flags,
+        )
+        .await
+        .unwrap();
+
+    let reply = filesystem
+        .copy_file_range(
+            Request::default(),
+            Some(source_path),
+            source.fh,
+            1,
+            Some(target_path),
+            target.fh,
+            0,
+            4,
+            0,
+        )
+        .await
+        .unwrap();
+    assert_eq!(reply.copied, 4);
+
+    filesystem
+        .release(
+            Request::default(),
+            Some(target_path),
+            target.fh,
+            target_flags,
+            0,
+            false,
+        )
+        .await
+        .unwrap();
+    filesystem
+        .release(
+            Request::default(),
+            Some(source_path),
+            source.fh,
+            source_flags,
+            0,
+            false,
+        )
+        .await
+        .unwrap();
+
+    let content = operator.read("target.txt").await.unwrap().to_bytes();
+    assert_eq!(content.as_ref(), b"ello");
+}

--- a/tests/file_system.rs
+++ b/tests/file_system.rs
@@ -117,6 +117,18 @@ async fn test_read_honors_requested_range() {
         .unwrap();
     assert_eq!(reply.data.as_ref(), b"ello");
 
+    let reply = filesystem
+        .read(Request::default(), Some(path), opened.fh, 8, 8)
+        .await
+        .unwrap();
+    assert_eq!(reply.data.as_ref(), b"rld");
+
+    let reply = filesystem
+        .read(Request::default(), Some(path), opened.fh, 11, 4)
+        .await
+        .unwrap();
+    assert!(reply.data.is_empty());
+
     filesystem
         .release(Request::default(), Some(path), opened.fh, flags, 0, false)
         .await

--- a/tests/file_system.rs
+++ b/tests/file_system.rs
@@ -103,7 +103,7 @@ async fn test_read_honors_requested_range() {
         .finish();
     operator.write("source.txt", "hello world").await.unwrap();
 
-    let filesystem = fuse3_opendal::Filesystem::new(operator, 0, 0);
+    let filesystem = fuse3_opendal::Filesystem::new(operator.clone(), 0, 0);
     let path = OsStr::new("source.txt");
     let flags = libc::O_RDONLY as u32;
     let opened = filesystem
@@ -128,6 +128,13 @@ async fn test_read_honors_requested_range() {
         .await
         .unwrap();
     assert!(reply.data.is_empty());
+
+    operator.write("source.txt", "hello world!").await.unwrap();
+    let reply = filesystem
+        .read(Request::default(), Some(path), opened.fh, 11, 4)
+        .await
+        .unwrap();
+    assert_eq!(reply.data.as_ref(), b"!");
 
     filesystem
         .release(Request::default(), Some(path), opened.fh, flags, 0, false)


### PR DESCRIPTION
## Summary

- bound each OpenDAL read to the exact FUSE `offset..offset + size` range
- reject overflowing range calculations with `EOVERFLOW`
- add regression coverage for partial reads and `copy_file_range` length limits

## Root cause

The FUSE read callback forwarded `offset..` to OpenDAL and ignored the requested `size`. Partial reads therefore fetched the entire remaining object, and `copy_file_range` could pass more data to the destination than its requested length.

## Impact

Reads now request only the bytes needed by FUSE. This prevents remote over-read amplification for large files and keeps `copy_file_range` within its requested range.

## Checks

- `cargo fmt --all -- --check`
- `cargo test --test file_system`
- `cargo clippy --all-targets --all-features -- -D warnings`
