### PR TITLE
fix(fuse): avoid echoing POSIX open flags

### DIFF
--- a/integrations/fuse3/src/file_system.rs
+++ b/integrations/fuse3/src/file_system.rs
@@ -355,7 +355,7 @@ impl PathFilesystem for Filesystem {
 
     async fn opendir(&self, _req: Request, path: &OsStr, flags: u32) -> Result<ReplyOpen> {
         log::debug!("opendir(path={path:?}, flags=0x{flags:x})");
-        Ok(ReplyOpen { fh: 0, flags })
+        Ok(ReplyOpen { fh: 0, flags: 0 })
     }
 
     async fn open(&self, _req: Request, path: &OsStr, flags: u32) -> Result<ReplyOpen> {
@@ -404,7 +404,7 @@ impl PathFilesystem for Filesystem {
 
         Ok(ReplyOpen {
             fh: FileKey(key).to_fh(),
-            flags,
+            flags: 0,
         })
     }
 
@@ -640,7 +640,7 @@ impl PathFilesystem for Filesystem {
             attr,
             generation: 0,
             fh: FileKey(key).to_fh(),
-            flags,
+            flags: 0,
         })
     }
 

--- a/integrations/fuse3/src/file_system.rs
+++ b/integrations/fuse3/src/file_system.rs
@@ -43,6 +43,10 @@ use super::file::OpenedFile;
 
 const TTL: Duration = Duration::from_secs(1); // 1 second
 
+/// FUSE reply flags (`FOPEN_*`) are independent from POSIX request flags (`O_*`).
+/// Advertise no optional open behavior until the filesystem defines an explicit policy.
+const FUSE_OPEN_REPLY_FLAGS: u32 = 0;
+
 /// `Filesystem` represents the filesystem that implements [`PathFilesystem`] by opendal.
 ///
 /// `Filesystem` must be used along with `fuse3`'s `Session` like the following:
@@ -355,7 +359,10 @@ impl PathFilesystem for Filesystem {
 
     async fn opendir(&self, _req: Request, path: &OsStr, flags: u32) -> Result<ReplyOpen> {
         log::debug!("opendir(path={path:?}, flags=0x{flags:x})");
-        Ok(ReplyOpen { fh: 0, flags: 0 })
+        Ok(ReplyOpen {
+            fh: 0,
+            flags: FUSE_OPEN_REPLY_FLAGS,
+        })
     }
 
     async fn open(&self, _req: Request, path: &OsStr, flags: u32) -> Result<ReplyOpen> {
@@ -404,7 +411,7 @@ impl PathFilesystem for Filesystem {
 
         Ok(ReplyOpen {
             fh: FileKey(key).to_fh(),
-            flags: 0,
+            flags: FUSE_OPEN_REPLY_FLAGS,
         })
     }
 
@@ -640,7 +647,7 @@ impl PathFilesystem for Filesystem {
             attr,
             generation: 0,
             fh: FileKey(key).to_fh(),
-            flags: 0,
+            flags: FUSE_OPEN_REPLY_FLAGS,
         })
     }
 

--- a/tests/file_system.rs
+++ b/tests/file_system.rs
@@ -93,3 +93,68 @@ async fn test_flush_keeps_file_handle_open() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn test_open_replies_do_not_echo_posix_flags() {
+    let root = tempfile::tempdir().unwrap();
+    let root_path = root.path().to_string_lossy().to_string();
+    let operator = Operator::new(services::Fs::default().root(&root_path))
+        .unwrap()
+        .finish();
+    operator.write("source.txt", "hello").await.unwrap();
+
+    let filesystem = fuse3_opendal::Filesystem::new(operator, 0, 0);
+    let source_path = OsStr::new("source.txt");
+    for flags in [
+        (libc::O_WRONLY | libc::O_TRUNC) as u32,
+        (libc::O_RDWR | libc::O_TRUNC) as u32,
+    ] {
+        let opened = filesystem
+            .open(Request::default(), source_path, flags)
+            .await
+            .unwrap();
+        assert_eq!(opened.flags, 0);
+        filesystem
+            .release(
+                Request::default(),
+                Some(source_path),
+                opened.fh,
+                flags,
+                0,
+                false,
+            )
+            .await
+            .unwrap();
+    }
+
+    let target_path = OsStr::new("target.txt");
+    let create_flags = (libc::O_WRONLY | libc::O_TRUNC) as u32;
+    let created = filesystem
+        .create(
+            Request::default(),
+            OsStr::new(""),
+            target_path,
+            0o644,
+            create_flags,
+        )
+        .await
+        .unwrap();
+    assert_eq!(created.flags, 0);
+    filesystem
+        .release(
+            Request::default(),
+            Some(target_path),
+            created.fh,
+            create_flags,
+            0,
+            false,
+        )
+        .await
+        .unwrap();
+
+    let directory = filesystem
+        .opendir(Request::default(), OsStr::new(""), libc::O_DIRECTORY as u32)
+        .await
+        .unwrap();
+    assert_eq!(directory.flags, 0);
+}


### PR DESCRIPTION
## Summary

- stop returning POSIX `O_*` flags as FUSE `FOPEN_*` reply flags
- leave FUSE open, create, and opendir reply flags unset until an explicit cache policy is selected
- add regression coverage for write-only, read-write, create, and directory open replies

## Root cause

The `flags` argument received by the FUSE callbacks contains POSIX open flags, while `ReplyOpen.flags` and `ReplyCreated.flags` are interpreted by the kernel as FUSE-specific response flags. Echoing the input accidentally maps `O_WRONLY` to `FOPEN_DIRECT_IO` and `O_RDWR` to `FOPEN_KEEP_CACHE` because those constants use the same low bits.

## Impact

Open behavior no longer changes accidentally based on unrelated numeric overlap between the POSIX and FUSE flag namespaces. Direct I/O and cache retention can be enabled later only through an explicit filesystem policy.

## Checks

- `cargo fmt --all -- --check`
- `cargo test --locked --test file_system`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
