### PR TITLE
feat: add managed data access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,14 +49,78 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -78,10 +142,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -90,6 +169,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -98,6 +179,23 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
 
 [[package]]
 name = "ciborium"
@@ -167,10 +265,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "console"
@@ -180,14 +303,36 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -205,6 +350,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctor"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,7 +450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -233,10 +466,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
@@ -250,10 +557,28 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -263,8 +588,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
+ "rand_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -279,10 +619,241 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "insta"
@@ -297,10 +868,136 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "js-sys",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -320,14 +1017,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "link-section"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
+name = "mea"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c709842c4ce65cb91e2666ad5319dfc1efc3af0d34f02075eddca9000d9f8afb"
+dependencies = [
+ "hashbrown",
+ "slab",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ofs"
 version = "0.0.24"
+
+[[package]]
+name = "ofs-core"
+version = "0.0.24"
+dependencies = [
+ "blake3",
+ "futures",
+ "ofs-managed-format",
+ "opendal",
+ "serde",
+ "tokio",
+ "tokio-util",
+]
 
 [[package]]
 name = "ofs-managed-format"
@@ -355,10 +1132,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opendal"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c9c85ce253ff87225e7669979d877a20c98a06604ec9d6dd5f4473e08f1ae1"
+dependencies = [
+ "ctor",
+ "opendal-core",
+ "opendal-layer-concurrent-limit",
+ "opendal-layer-logging",
+ "opendal-layer-retry",
+ "opendal-layer-timeout",
+]
+
+[[package]]
+name = "opendal-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f8607c90e2c963a91467f50fb49fbc7fb3d573f88cea219ca59ccd3740b309"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "jiff",
+ "log",
+ "md-5",
+ "mea",
+ "percent-encoding",
+ "quick-xml",
+ "reqsign-core",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "opendal-layer-concurrent-limit"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6f81ba6960e3fae1882f253b114b21d7e444e1534f209c7737a79f6243eb6f"
+dependencies = [
+ "futures",
+ "http",
+ "mea",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-logging"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ada45c6d81d1aa4c9305d0c7d4bc317c59c85866a0908a2d75a7a978aa5ee2"
+dependencies = [
+ "log",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-retry"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2a25a718afb81fad81cb9a0580a1cb989221fa2317f888c6a37f8dad408eb7"
+dependencies = [
+ "backon",
+ "log",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-timeout"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91f731724c213af81e9d03517859c8fc47b4578e64ad61ae4f099f10fe36e3"
+dependencies = [
+ "opendal-core",
+ "tokio",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -367,6 +1271,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -385,16 +1356,206 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "reqsign-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff052daffb0599681c50f85c59e7236438976efe991ab864edd9f3b235501a0f"
+dependencies = [
+ "anyhow",
+ "base64 0.23.1",
+ "bytes",
+ "futures",
+ "hex",
+ "hmac",
+ "http",
+ "jiff",
+ "log",
+ "mea",
+ "percent-encoding",
+ "sha1",
+ "sha2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -402,6 +1563,53 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -434,10 +1642,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -452,10 +1711,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -480,16 +1767,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -506,6 +1843,131 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-casefold"
@@ -529,6 +1991,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,10 +2026,36 @@ version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -556,6 +2068,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -591,6 +2113,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "which"
 version = "8.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,10 +2164,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -615,11 +2197,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
 name = "x"
 version = "0.0.0"
 dependencies = [
  "clap",
  "which",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
@@ -641,3 +2316,69 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [workspace]
-members = [".", "crates/managed-format", "xtask"]
+members = [".", "crates/core", "crates/managed-format", "xtask"]
 resolver = "3"
 
 [workspace.package]
@@ -44,6 +44,8 @@ rust-version = "1.91.0"
 [workspace.dependencies]
 blake3 = "1"
 clap = { version = "4.6.5", features = ["derive"] }
+futures = "0.3"
+tokio-util = { version = "0.7", features = ["io"] }
 which = { version = "8.0.5" }
 
 [workspace.metadata.release]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+description = "Managed filesystem core for Apache OpenDAL File System"
+edition.workspace = true
+license.workspace = true
+name = "ofs-core"
+publish = false
+repository.workspace = true
+rust-version.workspace = true
+version = "0.0.24"
+
+[dependencies]
+blake3.workspace = true
+futures.workspace = true
+ofs-managed-format = { path = "../managed-format" }
+opendal = "0.57.0"
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["io-util"] }
+tokio-util.workspace = true
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/core/src/data/codec.rs
+++ b/crates/core/src/data/codec.rs
@@ -1,0 +1,185 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Extent encoding. Identity is base; Zstandard implements this port.
+
+use std::fmt;
+use std::future::Future;
+use std::ops::Range;
+
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::Error;
+use crate::filesystem::ContentRef;
+use crate::format::{ExtensionDescriptor, ExtentRef, ObjectClass, SegmentRangeRef};
+
+use super::range::RangeReader;
+use super::segment::DataSegmentWriter;
+
+/// Incremental content identity used with Tokio's stream inspection adapters.
+#[derive(Default)]
+pub struct ContentHasher {
+    hasher: blake3::Hasher,
+    length: u64,
+    complete: bool,
+}
+
+impl ContentHasher {
+    /// Observe bytes read from a source, including the empty EOF observation.
+    pub fn observe(&mut self, bytes: &[u8]) {
+        if bytes.is_empty() {
+            self.complete = true;
+            return;
+        }
+        self.hasher.update(bytes);
+        self.length = self
+            .length
+            .checked_add(bytes.len() as u64)
+            .expect("one byte stream cannot exceed the u64 format range");
+    }
+
+    /// Return the identity of all bytes observed so far.
+    pub fn content(&self) -> ContentRef {
+        ContentRef::new(
+            crate::filesystem::Digest::from_bytes(self.hasher.finalize().into()),
+            self.length,
+        )
+    }
+
+    /// Return the content identity after the source has reached EOF.
+    pub fn complete_content(&self) -> Option<ContentRef> {
+        self.complete.then(|| self.content())
+    }
+}
+
+/// Physical-to-logical extent encoding.
+pub trait ExtentCodec: Send + Sync + Clone + fmt::Debug + Unpin + 'static {
+    fn descriptor(&self) -> Option<&ExtensionDescriptor>;
+
+    fn decoding_count(&self) -> usize;
+
+    fn stored_size_bound(&self, logical_bytes: u64) -> Option<u64>;
+
+    fn stored_range(&self, reference: &ExtentRef, range: Range<u64>) -> Result<Range<u64>, Error>;
+
+    fn validate(&self, reference: &ExtentRef) -> Result<(), Error> {
+        if reference.stored_range.segment.class != ObjectClass::DataSegment
+            || reference.stored_range.stored_content.length() == 0
+            || reference.content().length() == 0
+            || reference.decoding_outputs.len() != self.decoding_count()
+        {
+            return Err(Error::corrupt(
+                "read Managed file",
+                "file extent does not match the access chain",
+            ));
+        }
+        reference
+            .stored_range
+            .offset
+            .checked_add(reference.stored_range.stored_content.length())
+            .ok_or_else(|| Error::corrupt("read Managed file", "stored extent range overflows"))?;
+        Ok(())
+    }
+
+    fn encode<'a>(
+        &'a self,
+        placement: &'a mut DataSegmentWriter<'_>,
+        source: &'a mut (dyn AsyncRead + Send + Unpin),
+    ) -> impl Future<Output = Result<ExtentRef, Error>> + Send + 'a;
+
+    fn decode<'a>(
+        &'a self,
+        source: &'a mut RangeReader,
+        reference: ExtentRef,
+        range: Range<u64>,
+        destination: &'a mut (dyn AsyncWrite + Send + Unpin),
+    ) -> impl Future<Output = Result<(), Error>> + Send + 'a;
+}
+
+/// Identity extent encoding backed by the common self-delimiting stream format.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct IdentityCodec;
+
+impl ExtentCodec for IdentityCodec {
+    fn descriptor(&self) -> Option<&ExtensionDescriptor> {
+        None
+    }
+
+    fn decoding_count(&self) -> usize {
+        0
+    }
+
+    fn stored_size_bound(&self, logical_bytes: u64) -> Option<u64> {
+        Some(logical_bytes)
+    }
+
+    fn stored_range(&self, reference: &ExtentRef, range: Range<u64>) -> Result<Range<u64>, Error> {
+        identity_range(reference, range)
+    }
+
+    async fn encode(
+        &self,
+        placement: &mut DataSegmentWriter<'_>,
+        source: &mut (dyn AsyncRead + Send + Unpin),
+    ) -> Result<ExtentRef, Error> {
+        let (locator, offset, stored) = placement.append(source).await?;
+        Ok(ExtentRef {
+            stored_range: SegmentRangeRef {
+                segment: locator,
+                offset,
+                stored_content: stored,
+            },
+            decoding_outputs: Vec::new(),
+        })
+    }
+
+    async fn decode(
+        &self,
+        source: &mut RangeReader,
+        reference: ExtentRef,
+        range: Range<u64>,
+        destination: &mut (dyn AsyncWrite + Send + Unpin),
+    ) -> Result<(), Error> {
+        let range = identity_range(&reference, range)?;
+        if range.is_empty() {
+            return Ok(());
+        }
+        if range.start == 0 && range.end == reference.stored_range.stored_content.length() {
+            source
+                .copy_file(reference.stored_range.stored_content, destination)
+                .await
+        } else {
+            source
+                .copy_bytes(range.end - range.start, destination)
+                .await
+        }
+    }
+}
+
+fn identity_range(reference: &ExtentRef, range: Range<u64>) -> Result<Range<u64>, Error> {
+    if !reference.decoding_outputs.is_empty()
+        || reference.stored_range.segment.class != ObjectClass::DataSegment
+        || range.start > range.end
+        || range.end > reference.stored_range.stored_content.length()
+    {
+        return Err(Error::corrupt(
+            "read Managed extent",
+            "extent reference does not use identity encoding",
+        ));
+    }
+    Ok(range)
+}

--- a/crates/core/src/data/extent.rs
+++ b/crates/core/src/data/extent.rs
@@ -1,0 +1,434 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Canonical extent-run streaming and materialization.
+
+use std::num::NonZeroUsize;
+
+use opendal::Operator;
+
+use crate::Error;
+use crate::format::{
+    ExtentMapping, ExtentRunRef, FileExtentMap, FileRange, ObjectClass, StreamKind,
+};
+use crate::storage::{RecordStreamReader, RecordStreamWriter};
+
+use super::file_range_end;
+
+/// Single-pass canonical view over all of one file's extent runs.
+pub(crate) struct FileExtentReader {
+    runs: Vec<FileExtentRunReader>,
+    position: Option<u64>,
+    pending: Option<ExtentMapping>,
+}
+
+/// Single-pass reader over one internally canonical extent run.
+pub(crate) struct FileExtentRunReader {
+    reference: ExtentRunRef,
+    first: Option<ExtentMapping>,
+    tail: Option<RecordStreamReader<ExtentMapping>>,
+    previous_end: Option<u64>,
+    head: Option<ExtentMapping>,
+}
+
+/// Forward-only writer for one canonical extent run.
+pub struct ExtentRunWriter<'a> {
+    operator: &'a Operator,
+    gc_epoch: crate::format::GcEpoch,
+    multipart_part_bytes: NonZeroUsize,
+    first: Option<ExtentMapping>,
+    tail: Option<RecordStreamWriter>,
+    previous_end: Option<u64>,
+    covered_bytes: u64,
+}
+
+/// Open the canonical newest-wins logical extent stream.
+pub(crate) async fn open_file_extents(
+    reference: &FileExtentMap,
+    operator: &Operator,
+    selection: Option<FileRange>,
+) -> Result<FileExtentReader, Error> {
+    let mut runs = Vec::new();
+    for reference in reference.runs() {
+        if let Some(selection) = selection
+            && (file_range_end(reference.span)? <= selection.offset
+                || file_range_end(selection)? <= reference.span.offset)
+        {
+            continue;
+        }
+        let mut run = open_extent_run(reference, operator).await?;
+        run.head = run.next().await?;
+        runs.push(run);
+    }
+    Ok(FileExtentReader {
+        runs,
+        position: selection.map(|range| range.offset),
+        pending: None,
+    })
+}
+
+/// Add one newer patch run using deterministic binary carry.
+pub(crate) async fn add_extent_run(
+    mut reference: FileExtentMap,
+    operator: &Operator,
+    gc_epoch: crate::format::GcEpoch,
+    multipart_part_bytes: NonZeroUsize,
+    carry: ExtentRunRef,
+) -> Result<FileExtentMap, Error> {
+    let mut runs = vec![carry];
+    for level in 0..u64::BITS as usize {
+        if reference.patch_levels.len() == level {
+            reference.patch_levels.push(Some(
+                materialize_runs(operator, gc_epoch, multipart_part_bytes, runs, |_| Ok(()))
+                    .await?,
+            ));
+            return Ok(reference);
+        }
+        match reference.patch_levels[level].take() {
+            None => {
+                reference.patch_levels[level] = Some(
+                    materialize_runs(operator, gc_epoch, multipart_part_bytes, runs, |_| Ok(()))
+                        .await?,
+                );
+                while reference.patch_levels.last().is_some_and(Option::is_none) {
+                    reference.patch_levels.pop();
+                }
+                return Ok(reference);
+            }
+            Some(older) => runs.push(older),
+        }
+    }
+    runs.push(reference.base_run.take().ok_or_else(|| {
+        Error::corrupt(
+            "merge Managed file extent runs",
+            "a patched file has no base extent run",
+        )
+    })?);
+    reference.base_run =
+        Some(materialize_runs(operator, gc_epoch, multipart_part_bytes, runs, |_| Ok(())).await?);
+    reference.patch_levels.clear();
+    Ok(reference)
+}
+
+/// Materialize a layered mapping as one canonical base run.
+pub async fn compact_file_extents(
+    reference: &FileExtentMap,
+    operator: &Operator,
+    gc_epoch: crate::format::GcEpoch,
+    multipart_part_bytes: NonZeroUsize,
+    mut visit: impl FnMut(&ExtentMapping) -> Result<(), Error>,
+) -> Result<FileExtentMap, Error> {
+    if reference.base_run.is_none() {
+        return Ok(FileExtentMap::empty());
+    }
+    if reference.patch_levels.is_empty() {
+        let mut extents = open_file_extents(reference, operator, None).await?;
+        while let Some(mapping) = extents.next().await? {
+            visit(&mapping)?;
+        }
+        return Ok(reference.clone());
+    }
+    let runs = reference.runs().cloned().collect();
+    Ok(FileExtentMap::from_base(
+        materialize_runs(operator, gc_epoch, multipart_part_bytes, runs, visit).await?,
+    ))
+}
+
+async fn materialize_runs(
+    operator: &Operator,
+    gc_epoch: crate::format::GcEpoch,
+    multipart_part_bytes: NonZeroUsize,
+    mut runs: Vec<ExtentRunRef>,
+    mut visit: impl FnMut(&ExtentMapping) -> Result<(), Error>,
+) -> Result<ExtentRunRef, Error> {
+    if runs.len() == 1 {
+        return Ok(runs.pop().expect("one extent run remains"));
+    }
+    let base = runs.pop().ok_or_else(|| {
+        Error::invalid(
+            "merge Managed file extent runs",
+            "extent-run merge is empty",
+        )
+    })?;
+    let overlay = FileExtentMap {
+        base_run: Some(base),
+        patch_levels: runs.into_iter().map(Some).collect(),
+    };
+    let mut writer = ExtentRunWriter::new(operator, gc_epoch, multipart_part_bytes);
+    let mut extents = open_file_extents(&overlay, operator, None).await?;
+    while let Some(mapping) = extents.next().await? {
+        visit(&mapping)?;
+        writer.write(mapping).await?;
+    }
+    writer.close().await?.ok_or_else(|| {
+        Error::corrupt(
+            "merge Managed file extent runs",
+            "extent-run overlay is empty",
+        )
+    })
+}
+
+impl<'a> ExtentRunWriter<'a> {
+    /// Start an extent run without opening a remote object.
+    pub(crate) const fn new(
+        operator: &'a Operator,
+        gc_epoch: crate::format::GcEpoch,
+        multipart_part_bytes: NonZeroUsize,
+    ) -> Self {
+        Self {
+            operator,
+            gc_epoch,
+            multipart_part_bytes,
+            first: None,
+            tail: None,
+            previous_end: None,
+            covered_bytes: 0,
+        }
+    }
+
+    /// Append one logical mapping in strict non-overlapping offset order.
+    pub async fn write(&mut self, mapping: ExtentMapping) -> Result<(), Error> {
+        mapping.validate()?;
+        if self
+            .previous_end
+            .is_some_and(|previous| mapping.logical_range.offset < previous)
+        {
+            return Err(Error::invalid(
+                "write Managed file extent run",
+                "file extents overlap or are out of order",
+            ));
+        }
+        self.previous_end = Some(mapping.end()?);
+        self.covered_bytes = self
+            .covered_bytes
+            .checked_add(mapping.logical_range.length)
+            .ok_or_else(|| Error::invalid("write Managed file extent run", "coverage overflows"))?;
+        if self.first.is_none() {
+            self.first = Some(mapping);
+            return Ok(());
+        }
+        if self.tail.is_none() {
+            self.tail = Some(
+                RecordStreamWriter::open(
+                    self.operator,
+                    self.gc_epoch,
+                    ObjectClass::FileExtentSegment,
+                    StreamKind::FILE_EXTENTS,
+                    self.multipart_part_bytes,
+                )
+                .await?,
+            );
+        }
+        self.tail
+            .as_mut()
+            .expect("file extent run tail is open")
+            .write(&mapping)
+            .await
+    }
+
+    /// Return whether the mappings cover exactly one contiguous logical range.
+    pub(crate) fn covers(&self, range: FileRange) -> bool {
+        self.first.as_ref().is_some_and(|first| {
+            first.logical_range.offset == range.offset
+                && self.previous_end == range.end().ok()
+                && self.covered_bytes == range.length
+        })
+    }
+
+    /// Finish the non-empty run.
+    pub(crate) async fn close(self) -> Result<Option<ExtentRunRef>, Error> {
+        let Some(first) = self.first else {
+            return Ok(None);
+        };
+        let end = self
+            .previous_end
+            .expect("a file extent run with a first item has an end");
+        let span = FileRange::new(first.logical_range.offset, end - first.logical_range.offset)?;
+        let continuation = match self.tail {
+            Some(tail) => Some(tail.close().await?),
+            None => None,
+        };
+        Ok(Some(ExtentRunRef {
+            span,
+            inline_extent: first,
+            continuation,
+        }))
+    }
+
+    pub(super) async fn abort(self) {
+        if let Some(tail) = self.tail {
+            tail.abort().await;
+        }
+    }
+}
+
+impl FileExtentReader {
+    /// Read the next canonical logical mapping.
+    pub(crate) async fn next(&mut self) -> Result<Option<ExtentMapping>, Error> {
+        loop {
+            let next = self.next_raw().await?;
+            match (self.pending.take(), next) {
+                (None, None) => return Ok(None),
+                (Some(pending), None) => return Ok(Some(pending)),
+                (None, Some(next)) => self.pending = Some(next),
+                (Some(pending), Some(next)) => match coalesce_file_extents(pending, next)? {
+                    Ok(combined) => self.pending = Some(combined),
+                    Err((pending, next)) => {
+                        self.pending = Some(next);
+                        return Ok(Some(pending));
+                    }
+                },
+            }
+        }
+    }
+
+    async fn next_raw(&mut self) -> Result<Option<ExtentMapping>, Error> {
+        loop {
+            let Some(position) = self.position.or_else(|| {
+                self.runs
+                    .iter()
+                    .filter_map(|run| {
+                        run.head
+                            .as_ref()
+                            .map(|mapping| mapping.logical_range.offset)
+                    })
+                    .min()
+            }) else {
+                return Ok(None);
+            };
+            self.position = Some(position);
+            for run in &mut self.runs {
+                while run
+                    .head
+                    .as_ref()
+                    .is_some_and(|mapping| mapping.end().ok().is_some_and(|end| end <= position))
+                {
+                    run.head = run.next().await?;
+                }
+            }
+            let Some((priority, selected)) =
+                self.runs.iter().enumerate().find_map(|(priority, run)| {
+                    run.head.as_ref().and_then(|mapping| {
+                        (mapping.logical_range.offset <= position
+                            && mapping.end().ok().is_some_and(|end| position < end))
+                        .then_some((priority, mapping))
+                    })
+                })
+            else {
+                self.position = self
+                    .runs
+                    .iter()
+                    .filter_map(|run| {
+                        run.head
+                            .as_ref()
+                            .map(|mapping| mapping.logical_range.offset)
+                    })
+                    .filter(|offset| *offset > position)
+                    .min();
+                continue;
+            };
+            let mut end = selected.end()?;
+            for newer in &self.runs[..priority] {
+                if let Some(mapping) = &newer.head
+                    && mapping.logical_range.offset > position
+                {
+                    end = end.min(mapping.logical_range.offset);
+                }
+            }
+            let selected = selected.slice(FileRange::new(position, end - position)?)?;
+            self.position = Some(end);
+            return Ok(Some(selected));
+        }
+    }
+}
+
+/// Open one run's ordered extent records without applying other levels.
+pub(crate) async fn open_extent_run(
+    reference: &ExtentRunRef,
+    operator: &Operator,
+) -> Result<FileExtentRunReader, Error> {
+    let tail = match reference.continuation {
+        Some(tail) => Some(RecordStreamReader::open(operator, tail).await?),
+        None => None,
+    };
+    Ok(FileExtentRunReader {
+        first: Some(reference.inline_extent.clone()),
+        reference: reference.clone(),
+        tail,
+        previous_end: None,
+        head: None,
+    })
+}
+
+impl FileExtentRunReader {
+    /// Read the next mapping in this run.
+    pub(crate) async fn next(&mut self) -> Result<Option<ExtentMapping>, Error> {
+        let mapping = match self.first.take() {
+            Some(first) => Some(first),
+            None => match self.tail.as_mut() {
+                Some(tail) => tail.next().await?,
+                None => None,
+            },
+        };
+        let Some(mapping) = mapping else {
+            if self.previous_end != Some(self.reference.span.end()?) {
+                return Err(Error::corrupt(
+                    "read Managed file extent run",
+                    "extent records do not match the run span",
+                ));
+            }
+            return Ok(None);
+        };
+        mapping.validate()?;
+        if self
+            .previous_end
+            .is_some_and(|previous| mapping.logical_range.offset < previous)
+            || mapping.logical_range.offset < self.reference.span.offset
+            || mapping.end()? > self.reference.span.end()?
+        {
+            return Err(Error::corrupt(
+                "read Managed file extent run",
+                "extent records overlap or fall outside the run span",
+            ));
+        }
+        self.previous_end = Some(mapping.end()?);
+        Ok(Some(mapping))
+    }
+}
+
+fn coalesce_file_extents(
+    mut left: ExtentMapping,
+    right: ExtentMapping,
+) -> Result<Result<ExtentMapping, (ExtentMapping, ExtentMapping)>, Error> {
+    let left_extent_end = left
+        .extent_offset
+        .checked_add(left.logical_range.length)
+        .ok_or_else(|| Error::corrupt("read Managed file", "extent offset overflows"))?;
+    if left.end()? == right.logical_range.offset
+        && left_extent_end == right.extent_offset
+        && left.extent == right.extent
+    {
+        left.logical_range.length = left
+            .logical_range
+            .length
+            .checked_add(right.logical_range.length)
+            .ok_or_else(|| Error::corrupt("read Managed file", "file range overflows"))?;
+        Ok(Ok(left))
+    } else {
+        Ok(Err((left, right)))
+    }
+}

--- a/crates/core/src/data/file.rs
+++ b/crates/core/src/data/file.rs
@@ -23,6 +23,7 @@ use opendal::Operator;
 use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncSeek, AsyncSeekExt as _, AsyncWrite};
 
 use crate::Error;
+use crate::data::ContentHasher;
 use crate::filesystem::ContentRef;
 use crate::format::{ExtentRef, FileExtentMap, FileRange, ObjectLocator};
 
@@ -272,12 +273,24 @@ pub async fn restore_file<A: DataAccess>(
     content: ContentRef,
     range: Range<u64>,
     reusable: Option<ReusableFile<'_>>,
-    destination: &mut (dyn AsyncWrite + Send + Unpin),
+    destination: &mut (impl AsyncWrite + Send + Unpin),
 ) -> Result<(), Error> {
     validate_file_map(&reference, content, access.decoding_count())?;
+    let complete_file = range.start == 0 && range.end == content.length();
     if range.is_empty() {
-        return Ok(());
+        return if !complete_file || ContentHasher::default().content() == content {
+            Ok(())
+        } else {
+            Err(Error::corrupt(
+                "read Managed file",
+                "restored bytes do not match the file content reference",
+            ))
+        };
     }
+    let mut restored = ContentHasher::default();
+    let mut destination =
+        tokio_util::io::InspectWriter::new(destination, |bytes| restored.observe(bytes));
+    let destination: &mut (dyn AsyncWrite + Send + Unpin) = &mut destination;
     let selection = FileRange::new(range.start, range.end - range.start)?;
     let mut mappings =
         super::extent::open_file_extents(&reference, operator, Some(selection)).await?;
@@ -415,6 +428,12 @@ pub async fn restore_file<A: DataAccess>(
         destination,
     )
     .await?;
+    if complete_file && restored.content() != content {
+        return Err(Error::corrupt(
+            "read Managed file",
+            "restored bytes do not match the file content reference",
+        ));
+    }
     Ok(())
 }
 

--- a/crates/core/src/data/file.rs
+++ b/crates/core/src/data/file.rs
@@ -1,0 +1,465 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Logical range planning and streaming restore.
+
+use std::ops::{Bound, Range, RangeBounds};
+
+use opendal::Operator;
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncSeek, AsyncSeekExt as _, AsyncWrite};
+
+use crate::Error;
+use crate::filesystem::ContentRef;
+use crate::format::{ExtentRef, FileExtentMap, FileRange, ObjectLocator};
+
+use super::DataAccess;
+use super::codec::ExtentCodec;
+use super::range::RangeReader;
+use super::validate_file_map;
+
+/// One item in a bounded range batch.
+pub(crate) struct RangeBatchItem<T> {
+    pub(crate) value: T,
+    pub(crate) range: Range<u64>,
+}
+
+/// One storage request plan for ranges from the same immutable segment.
+pub(crate) struct RangeBatch<T> {
+    locator: ObjectLocator,
+    items: Vec<RangeBatchItem<T>>,
+    metadata_bytes: u64,
+    range_bytes: u64,
+    contiguous: bool,
+    last_end: u64,
+}
+
+pub(crate) struct RangeBatchReader<T> {
+    items: std::vec::IntoIter<RangeBatchItem<T>>,
+    readers: BatchReaders,
+}
+
+enum BatchReaders {
+    Stream(RangeReader),
+    Fetched {
+        readers: std::vec::IntoIter<RangeReader>,
+        current: Option<RangeReader>,
+    },
+}
+
+/// Build range batches whose retained bytes fit one transfer lane.
+pub(crate) struct RangeBatcher<T> {
+    maximum_bytes: u64,
+    gap_bytes: u64,
+    current: Option<RangeBatch<T>>,
+}
+
+impl<T> RangeBatcher<T> {
+    pub(crate) fn new(maximum_bytes: usize, gap_bytes: usize) -> Self {
+        Self {
+            maximum_bytes: maximum_bytes as u64,
+            gap_bytes: gap_bytes as u64,
+            current: None,
+        }
+    }
+
+    pub(crate) fn push(
+        &mut self,
+        locator: ObjectLocator,
+        range: Range<u64>,
+        metadata_bytes: usize,
+        value: T,
+    ) -> Result<Option<RangeBatch<T>>, Error> {
+        if range.start >= range.end {
+            return Err(Error::corrupt(
+                "plan Managed segment ranges",
+                "data segment range is empty or reversed",
+            ));
+        }
+        let metadata_bytes = metadata_bytes as u64;
+        let fits = self.current.as_ref().is_none_or(|batch| {
+            batch.locator == locator
+                && batch
+                    .projected_bytes(&range, metadata_bytes, self.gap_bytes)
+                    .is_ok_and(|bytes| bytes <= self.maximum_bytes)
+        });
+        let ready = (!fits).then(|| self.current.take()).flatten();
+        match self.current.as_mut() {
+            Some(batch) => batch.push(range, metadata_bytes, value)?,
+            None => self.current = Some(RangeBatch::new(locator, range, metadata_bytes, value)),
+        }
+        Ok(ready)
+    }
+
+    pub(crate) fn take(&mut self) -> Option<RangeBatch<T>> {
+        self.current.take()
+    }
+}
+
+impl<T> RangeBatch<T> {
+    fn new(locator: ObjectLocator, range: Range<u64>, metadata_bytes: u64, value: T) -> Self {
+        let range_bytes = range.end - range.start;
+        let last_end = range.end;
+        Self {
+            locator,
+            items: vec![RangeBatchItem { value, range }],
+            metadata_bytes,
+            range_bytes,
+            contiguous: true,
+            last_end,
+        }
+    }
+
+    fn projected_bytes(
+        &self,
+        range: &Range<u64>,
+        metadata_bytes: u64,
+        gap_bytes: u64,
+    ) -> Result<u64, Error> {
+        let metadata_bytes = self
+            .metadata_bytes
+            .checked_add(metadata_bytes)
+            .ok_or_else(|| Error::corrupt("plan Managed segment ranges", "byte count overflows"))?;
+        if self.contiguous && self.last_end == range.start {
+            return Ok(metadata_bytes);
+        }
+        let range_bytes = self
+            .range_bytes
+            .checked_add(range.end - range.start)
+            .ok_or_else(|| Error::corrupt("plan Managed segment ranges", "byte count overflows"))?;
+        let gaps = gap_bytes
+            .checked_mul(self.items.len() as u64)
+            .ok_or_else(|| Error::corrupt("plan Managed segment ranges", "byte count overflows"))?;
+        metadata_bytes
+            .checked_add(range_bytes)
+            .and_then(|bytes| bytes.checked_add(gaps))
+            .ok_or_else(|| Error::corrupt("plan Managed segment ranges", "byte count overflows"))
+    }
+
+    fn push(&mut self, range: Range<u64>, metadata_bytes: u64, value: T) -> Result<(), Error> {
+        self.metadata_bytes = self
+            .metadata_bytes
+            .checked_add(metadata_bytes)
+            .ok_or_else(|| Error::corrupt("plan Managed segment ranges", "byte count overflows"))?;
+        self.range_bytes = self
+            .range_bytes
+            .checked_add(range.end - range.start)
+            .ok_or_else(|| Error::corrupt("plan Managed segment ranges", "byte count overflows"))?;
+        self.contiguous &= self.last_end == range.start;
+        self.last_end = range.end;
+        self.items.push(RangeBatchItem { value, range });
+        Ok(())
+    }
+
+    pub(crate) fn stream_range(&self) -> Option<Range<u64>> {
+        self.contiguous.then(|| {
+            self.items
+                .first()
+                .expect("a range batch is non-empty")
+                .range
+                .start..self.last_end
+        })
+    }
+
+    pub(crate) async fn read(
+        self,
+        operator: &Operator,
+        gap_bytes: usize,
+    ) -> Result<RangeBatchReader<T>, Error> {
+        let locator = self.locator;
+        let range = self.stream_range();
+        let items = self.items;
+        let readers = match range {
+            Some(range) => BatchReaders::Stream(RangeReader::open(operator, locator, range).await?),
+            None => {
+                let ranges = items.iter().map(|item| item.range.clone()).collect();
+                BatchReaders::Fetched {
+                    readers: RangeReader::fetch(operator, locator, ranges, gap_bytes)
+                        .await?
+                        .into_iter(),
+                    current: None,
+                }
+            }
+        };
+        Ok(RangeBatchReader {
+            items: items.into_iter(),
+            readers,
+        })
+    }
+}
+
+impl<T> RangeBatchReader<T> {
+    pub(crate) fn next(&mut self) -> Option<(T, &mut RangeReader)> {
+        let item = self.items.next()?;
+        let reader = match &mut self.readers {
+            BatchReaders::Stream(reader) => reader,
+            BatchReaders::Fetched { readers, current } => {
+                *current = Some(
+                    readers
+                        .next()
+                        .expect("a fetched reader exists for every range batch item"),
+                );
+                current.as_mut().expect("the fetched reader was stored")
+            }
+        };
+        Some((item.value, reader))
+    }
+}
+
+struct RemoteExtent {
+    reference: ExtentRef,
+    logical: Range<u64>,
+}
+
+impl RemoteExtent {
+    fn metadata_bytes(&self) -> u64 {
+        size_of::<Self>().saturating_add(
+            self.reference
+                .decoding_outputs
+                .len()
+                .saturating_mul(size_of::<ContentRef>()),
+        ) as u64
+    }
+}
+
+async fn read_remote_batch<C: ExtentCodec>(
+    batch: Option<RangeBatch<RemoteExtent>>,
+    codec: &C,
+    operator: &Operator,
+    read_gap_bytes: usize,
+    destination: &mut (dyn AsyncWrite + Send + Unpin),
+) -> Result<(), Error> {
+    let Some(batch) = batch else {
+        return Ok(());
+    };
+    let mut batch = batch.read(operator, read_gap_bytes).await?;
+    while let Some((extent, reader)) = batch.next() {
+        codec
+            .decode(reader, extent.reference, extent.logical, destination)
+            .await?;
+    }
+    Ok(())
+}
+
+pub struct ReusableFile<'a> {
+    pub reference: FileExtentMap,
+    pub source: &'a mut (dyn ReusableFileSource + 'a),
+}
+
+pub trait ReusableFileSource: AsyncRead + AsyncSeek + Send + Unpin {}
+
+impl<T> ReusableFileSource for T where T: AsyncRead + AsyncSeek + Send + Unpin {}
+
+pub async fn restore_file<A: DataAccess>(
+    access: &A,
+    operator: &Operator,
+    read_gap_bytes: usize,
+    read_window_bytes: usize,
+    reference: FileExtentMap,
+    content: ContentRef,
+    range: Range<u64>,
+    reusable: Option<ReusableFile<'_>>,
+    destination: &mut (dyn AsyncWrite + Send + Unpin),
+) -> Result<(), Error> {
+    validate_file_map(&reference, content, access.decoding_count())?;
+    if range.is_empty() {
+        return Ok(());
+    }
+    let selection = FileRange::new(range.start, range.end - range.start)?;
+    let mut mappings =
+        super::extent::open_file_extents(&reference, operator, Some(selection)).await?;
+    let (mut existing, mut reusable_source) = match reusable {
+        Some(reusable) => (
+            Some(
+                super::extent::open_file_extents(&reusable.reference, operator, Some(selection))
+                    .await?,
+            ),
+            Some(reusable.source),
+        ),
+        None => (None, None),
+    };
+    let mut existing_mapping = None::<crate::format::ExtentMapping>;
+    let mut remote = RangeBatcher::new(read_window_bytes, read_gap_bytes);
+    let mut expected_offset = range.start;
+    while let Some(mapping) = mappings.next().await? {
+        access.validate_extent(&mapping.extent)?;
+        if mapping.logical_range.offset != expected_offset {
+            return Err(Error::corrupt(
+                "read Managed file",
+                "file extents contain a gap or overlap",
+            ));
+        }
+        let mapping_end = mapping.end()?;
+        if let Some(existing) = existing.as_mut() {
+            while existing_mapping.as_ref().is_none_or(|candidate| {
+                candidate
+                    .end()
+                    .ok()
+                    .is_some_and(|end| end <= mapping.logical_range.offset)
+            }) {
+                let Some(candidate) = existing.next().await? else {
+                    existing_mapping = None;
+                    break;
+                };
+                access.validate_extent(&candidate.extent)?;
+                existing_mapping = Some(candidate);
+            }
+        }
+        if mapping.logical_range.offset < range.end && range.start < mapping_end {
+            let selected_start = range.start.max(mapping.logical_range.offset);
+            let selected_end = range.end.min(mapping_end);
+            let extent_start = mapping
+                .extent_offset
+                .checked_add(selected_start - mapping.logical_range.offset)
+                .ok_or_else(|| Error::corrupt("read Managed file", "extent offset overflows"))?;
+            let extent_end = extent_start
+                .checked_add(selected_end - selected_start)
+                .ok_or_else(|| Error::corrupt("read Managed file", "extent range overflows"))?;
+            let reusable_offset = existing_mapping.as_ref().and_then(|existing| {
+                let delta = mapping.extent_offset.checked_sub(existing.extent_offset)?;
+                let end = delta.checked_add(mapping.logical_range.length)?;
+                (existing.extent == mapping.extent && end <= existing.logical_range.length)
+                    .then_some(existing.logical_range.offset + delta)
+            });
+            if let (Some(source), Some(reusable_offset)) =
+                (reusable_source.as_deref_mut(), reusable_offset)
+            {
+                read_remote_batch(
+                    remote.take(),
+                    access.codec(),
+                    operator,
+                    read_gap_bytes,
+                    destination,
+                )
+                .await?;
+                copy_reusable(
+                    source,
+                    reusable_offset + selected_start - mapping.logical_range.offset,
+                    selected_end - selected_start,
+                    destination,
+                )
+                .await?;
+            } else {
+                let logical = extent_start..extent_end;
+                let stored = access
+                    .codec()
+                    .stored_range(&mapping.extent, logical.clone())?;
+                let physical_start = mapping
+                    .extent
+                    .stored_range
+                    .offset
+                    .checked_add(stored.start)
+                    .ok_or_else(|| {
+                        Error::corrupt("read Managed file", "stored range start overflows")
+                    })?;
+                let physical_end = mapping
+                    .extent
+                    .stored_range
+                    .offset
+                    .checked_add(stored.end)
+                    .ok_or_else(|| {
+                        Error::corrupt("read Managed file", "stored range end overflows")
+                    })?;
+                if physical_start >= physical_end {
+                    return Err(Error::corrupt("read Managed file", "stored range is empty"));
+                }
+                let locator = mapping.extent.stored_range.segment;
+                let physical = physical_start..physical_end;
+                let extent = RemoteExtent {
+                    reference: mapping.extent,
+                    logical,
+                };
+                let metadata_bytes = extent.metadata_bytes() as usize;
+                let ready = remote.push(locator, physical, metadata_bytes, extent)?;
+                read_remote_batch(ready, access.codec(), operator, read_gap_bytes, destination)
+                    .await?;
+            }
+        }
+        expected_offset = mapping_end;
+        if expected_offset >= range.end && range.end < content.length() {
+            read_remote_batch(
+                remote.take(),
+                access.codec(),
+                operator,
+                read_gap_bytes,
+                destination,
+            )
+            .await?;
+            return Ok(());
+        }
+    }
+    if expected_offset != range.end {
+        return Err(Error::corrupt(
+            "read Managed file",
+            "file extents do not cover the logical file",
+        ));
+    }
+    read_remote_batch(
+        remote.take(),
+        access.codec(),
+        operator,
+        read_gap_bytes,
+        destination,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn copy_reusable(
+    source: &mut (dyn ReusableFileSource + '_),
+    offset: u64,
+    length: u64,
+    destination: &mut (impl AsyncWrite + Send + Unpin + ?Sized),
+) -> Result<(), Error> {
+    source
+        .seek(std::io::SeekFrom::Start(offset))
+        .await
+        .map_err(|error| Error::io("seek reusable Managed file", error))?;
+    let copied = tokio::io::copy(&mut source.take(length), destination)
+        .await
+        .map_err(|error| Error::io("copy reusable Managed file", error))?;
+    if copied != length {
+        return Err(Error::conflict(
+            "copy reusable Managed file",
+            "verified local file changed during installation",
+        ));
+    }
+    Ok(())
+}
+
+pub fn logical_range(file_size: u64, range: impl RangeBounds<u64>) -> Result<Range<u64>, Error> {
+    let start = match range.start_bound() {
+        Bound::Included(offset) => *offset,
+        Bound::Excluded(offset) => offset
+            .checked_add(1)
+            .ok_or_else(|| Error::invalid("read Managed file range", "range start overflows"))?,
+        Bound::Unbounded => 0,
+    };
+    let end = match range.end_bound() {
+        Bound::Included(offset) => offset
+            .checked_add(1)
+            .ok_or_else(|| Error::invalid("read Managed file range", "range end overflows"))?,
+        Bound::Excluded(offset) => *offset,
+        Bound::Unbounded => file_size,
+    };
+    if start > end || end > file_size {
+        return Err(Error::invalid(
+            "read Managed file range",
+            "logical byte range is invalid",
+        ));
+    }
+    Ok(start..end)
+}

--- a/crates/core/src/data/lookup.rs
+++ b/crates/core/src/data/lookup.rs
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Reachable content lookup used by the file publication pipeline.
+
+use crate::Error;
+use crate::filesystem::ContentRef;
+use crate::format::{ExtentRef, FileExtentMap};
+
+/// Resolves logical content to an already-reachable physical representation.
+pub trait ContentLookup: Send + Sync {
+    fn file(&self, content: ContentRef) -> Result<Option<FileExtentMap>, Error>;
+
+    fn extent(&self, content: ContentRef) -> Result<Option<ExtentRef>, Error>;
+}

--- a/crates/core/src/data/mod.rs
+++ b/crates/core/src/data/mod.rs
@@ -15,12 +15,103 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Streaming placement, encoding, and verified reads for data segments.
+//! One file-data pipeline: partition, encode, place, and restore.
 
 mod codec;
+pub(crate) mod extent;
+mod file;
+mod lookup;
+mod partition;
 mod range;
 mod segment;
+pub(crate) mod write;
 
 pub use codec::{ContentHasher, ExtentCodec, IdentityCodec};
+pub use extent::{ExtentRunWriter, compact_file_extents};
+pub use file::{ReusableFile, ReusableFileSource, logical_range, restore_file};
+pub use lookup::ContentLookup;
+pub use partition::{FilePartitioner, WholePartitioner};
 pub use range::RangeReader;
 pub use segment::DataSegmentWriter;
+pub use write::{data_segments, publish_file, publish_file_patch};
+
+use crate::Error;
+use crate::format::FileRange;
+use crate::format::{ExtentRef, FileExtentMap};
+
+/// Compile-time family of file partitioning and extent encoding.
+pub trait DataAccess: Clone + Send + Sync + std::fmt::Debug + Unpin + 'static {
+    type Partitioner: FilePartitioner;
+    type Codec: ExtentCodec;
+
+    fn partitioner(&self) -> &Self::Partitioner;
+    fn codec(&self) -> &Self::Codec;
+
+    fn decoding_count(&self) -> usize {
+        self.codec().decoding_count()
+    }
+
+    fn stored_size_bound(&self, logical_bytes: u64) -> Option<u64> {
+        self.codec().stored_size_bound(logical_bytes)
+    }
+
+    fn validate_extent(&self, reference: &ExtentRef) -> Result<(), Error> {
+        self.codec().validate(reference)
+    }
+}
+
+/// Whole-file identity data access.
+#[derive(Clone, Debug, Default)]
+pub struct CoreDataAccess {
+    partitioner: WholePartitioner,
+    codec: IdentityCodec,
+}
+
+impl DataAccess for CoreDataAccess {
+    type Partitioner = WholePartitioner;
+    type Codec = IdentityCodec;
+
+    fn partitioner(&self) -> &Self::Partitioner {
+        &self.partitioner
+    }
+
+    fn codec(&self) -> &Self::Codec {
+        &self.codec
+    }
+}
+
+pub(crate) fn validate_file_map(
+    data: &FileExtentMap,
+    content: crate::filesystem::ContentRef,
+    decoding_count: usize,
+) -> Result<(), Error> {
+    data.validate(content)?;
+    if content.length() == 0 {
+        return Ok(());
+    }
+    if data.patch_levels.is_empty()
+        && let Some(mapping) = data.inline_file_extent()
+        && (mapping.logical_range.offset != 0
+            || mapping.extent_offset != 0
+            || mapping.logical_range.length != content.length()
+            || mapping.extent.content() != content)
+    {
+        return Err(Error::corrupt(
+            "read Managed file",
+            "single extent does not match the file content reference",
+        ));
+    }
+    for run in data.runs() {
+        if run.inline_extent.extent.decoding_outputs.len() != decoding_count {
+            return Err(Error::corrupt(
+                "read Managed file extent run",
+                "extent decoding chain does not match the volume",
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn file_range_end(range: FileRange) -> Result<u64, Error> {
+    Ok(range.end()?)
+}

--- a/crates/core/src/data/mod.rs
+++ b/crates/core/src/data/mod.rs
@@ -15,12 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! OpenDAL-backed runtime primitives for the Managed v0 format.
+//! Streaming placement, encoding, and verified reads for data segments.
 
-pub mod data;
-mod error;
-pub mod storage;
+mod codec;
+mod range;
+mod segment;
 
-pub use error::{Error, ErrorKind, Result};
-pub use ofs_managed_format::v0 as format;
-pub use ofs_managed_format::v0::model as filesystem;
+pub use codec::{ContentHasher, ExtentCodec, IdentityCodec};
+pub use range::RangeReader;
+pub use segment::DataSegmentWriter;

--- a/crates/core/src/data/partition.rs
+++ b/crates/core/src/data/partition.rs
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! File partitioning. Whole is base; FastCDC implements this port.
+
+use std::fmt;
+use std::future::Future;
+
+use tokio::io::AsyncRead;
+
+use crate::Error;
+use crate::filesystem::ContentRef;
+use crate::format::{ExtensionDescriptor, ExtentMapping};
+
+use super::codec::ExtentCodec;
+use super::extent::ExtentRunWriter;
+use super::lookup::ContentLookup;
+use super::segment::DataSegmentWriter;
+
+/// Logical file partitioning into independently encoded extents.
+pub trait FilePartitioner: Send + Sync + Clone + fmt::Debug + Unpin + 'static {
+    fn descriptor(&self) -> Option<&ExtensionDescriptor>;
+
+    /// Finite maximum logical extent, when the partitioner can provide one.
+    fn maximum_extent_bytes(&self) -> Option<u64>;
+
+    fn write_run<'a, C: ExtentCodec, K: ContentLookup + ?Sized>(
+        &'a self,
+        codec: &'a C,
+        placement: &'a mut DataSegmentWriter<'_>,
+        source: &'a mut (dyn AsyncRead + Send + Unpin),
+        known: &'a K,
+        file_offset: u64,
+        logical_bytes: u64,
+        run: &'a mut ExtentRunWriter<'_>,
+    ) -> impl Future<Output = Result<ContentRef, Error>> + Send + 'a;
+}
+
+/// Whole-file partitioner: one extent covers the entire logical write.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct WholePartitioner;
+
+impl FilePartitioner for WholePartitioner {
+    fn descriptor(&self) -> Option<&ExtensionDescriptor> {
+        None
+    }
+
+    fn maximum_extent_bytes(&self) -> Option<u64> {
+        None
+    }
+
+    async fn write_run<C: ExtentCodec, K: ContentLookup + ?Sized>(
+        &self,
+        codec: &C,
+        placement: &mut DataSegmentWriter<'_>,
+        source: &mut (dyn AsyncRead + Send + Unpin),
+        _known: &K,
+        file_offset: u64,
+        _logical_bytes: u64,
+        run: &mut ExtentRunWriter<'_>,
+    ) -> Result<ContentRef, Error> {
+        let extent = codec.encode(placement, source).await?;
+        let content = extent.content();
+        if content.length() != 0 {
+            run.write(ExtentMapping::complete(file_offset, extent)?)
+                .await?;
+        }
+        Ok(content)
+    }
+}

--- a/crates/core/src/data/range.rs
+++ b/crates/core/src/data/range.rs
@@ -1,0 +1,204 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Verified byte-range reads from immutable data segments.
+
+use std::ops::Range;
+
+use futures::StreamExt as _;
+use opendal::{Buffer, BufferStream, Operator};
+use tokio::io::{AsyncWrite, AsyncWriteExt as _};
+
+use crate::Error;
+use crate::filesystem::{ContentRef, Digest};
+use crate::format::{ObjectClass, ObjectLocator};
+
+/// One byte-range stream from a data segment.
+pub struct RangeReader {
+    stream: Option<BufferStream>,
+    pending: Buffer,
+    remaining: u64,
+}
+
+impl RangeReader {
+    /// Fetch exact ranges from one segment through OpenDAL's range planner.
+    pub async fn fetch(
+        operator: &Operator,
+        locator: ObjectLocator,
+        ranges: Vec<Range<u64>>,
+        gap_bytes: usize,
+    ) -> Result<Vec<Self>, Error> {
+        if locator.class != ObjectClass::DataSegment
+            || ranges.iter().any(|range| range.start > range.end)
+        {
+            return Err(Error::corrupt(
+                "fetch Managed data segment",
+                "data segment range reference is invalid",
+            ));
+        }
+        let expected_lengths = ranges
+            .iter()
+            .map(|range| range.end - range.start)
+            .collect::<Vec<_>>();
+        let reader = operator
+            .reader_with(&locator.key())
+            .gap(gap_bytes)
+            .await
+            .map_err(|error| Error::from_storage("open Managed data segment fetch", error))?;
+        let fetched = reader
+            .fetch(ranges)
+            .await
+            .map_err(|error| Error::from_storage("fetch Managed data segment ranges", error))?;
+        if fetched.len() != expected_lengths.len() {
+            return Err(Error::corrupt(
+                "fetch Managed data segment ranges",
+                "storage returned a different number of ranges",
+            ));
+        }
+        fetched
+            .into_iter()
+            .zip(expected_lengths)
+            .map(|(pending, expected)| {
+                if pending.len() as u64 != expected {
+                    return Err(Error::corrupt(
+                        "fetch Managed data segment ranges",
+                        "storage returned a truncated range",
+                    ));
+                }
+                Ok(Self {
+                    stream: None,
+                    remaining: expected,
+                    pending,
+                })
+            })
+            .collect()
+    }
+
+    /// Open a streaming byte range from one immutable data segment.
+    pub async fn open(
+        operator: &Operator,
+        locator: ObjectLocator,
+        range: Range<u64>,
+    ) -> Result<Self, Error> {
+        if locator.class != ObjectClass::DataSegment || range.start > range.end {
+            return Err(Error::corrupt(
+                "read Managed data segment",
+                "data segment range reference is invalid",
+            ));
+        }
+        let remaining = range.end - range.start;
+        let stream = operator
+            .reader(&locator.key())
+            .await
+            .map_err(|error| Error::from_storage("open Managed data segment", error))?
+            .into_stream(range)
+            .await
+            .map_err(|error| Error::from_storage("read Managed data segment", error))?;
+        Ok(Self {
+            stream: Some(stream),
+            pending: Buffer::new(),
+            remaining,
+        })
+    }
+
+    async fn refill(&mut self) -> Result<(), Error> {
+        if !self.pending.is_empty() {
+            return Ok(());
+        }
+        let Some(stream) = self.stream.as_mut() else {
+            return Err(Error::corrupt(
+                "read Managed data segment",
+                "fetched data segment range is truncated",
+            ));
+        };
+        self.pending = stream
+            .next()
+            .await
+            .ok_or_else(|| {
+                Error::corrupt(
+                    "read Managed data segment",
+                    "data segment range is truncated",
+                )
+            })?
+            .map_err(|error| Error::from_storage("read Managed data segment", error))?;
+        Ok(())
+    }
+
+    /// Consume and verify one complete stored range.
+    pub async fn copy_file(
+        &mut self,
+        content: ContentRef,
+        destination: &mut (impl AsyncWrite + Unpin + ?Sized),
+    ) -> Result<(), Error> {
+        let expected = content.length();
+        let mut hasher = blake3::Hasher::new();
+        self.copy_exact(expected, destination, Some(&mut hasher))
+            .await?;
+        if Digest::from_bytes(hasher.finalize().into()) != content.digest() {
+            return Err(Error::corrupt(
+                "read Managed data segment",
+                "stored range does not match its content reference",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn copy_bytes(
+        &mut self,
+        length: u64,
+        destination: &mut (impl AsyncWrite + Unpin + ?Sized),
+    ) -> Result<(), Error> {
+        self.copy_exact(length, destination, None).await
+    }
+
+    async fn copy_exact(
+        &mut self,
+        length: u64,
+        destination: &mut (impl AsyncWrite + Unpin + ?Sized),
+        mut hasher: Option<&mut blake3::Hasher>,
+    ) -> Result<(), Error> {
+        if length > self.remaining {
+            return Err(Error::corrupt(
+                "read Managed data segment",
+                "stored range exceeds the requested range",
+            ));
+        }
+        let mut remaining = length;
+        while remaining != 0 {
+            if self.pending.is_empty() {
+                self.refill().await?;
+            }
+            let take = usize::try_from(remaining)
+                .unwrap_or(usize::MAX)
+                .min(self.pending.len());
+            let bytes = self.pending.slice(..take);
+            self.pending = self.pending.slice(take..);
+            for chunk in bytes {
+                if let Some(hasher) = hasher.as_deref_mut() {
+                    hasher.update(&chunk);
+                }
+                destination
+                    .write_all(&chunk)
+                    .await
+                    .map_err(|error| Error::io("write Managed data segment destination", error))?;
+            }
+            remaining -= take as u64;
+            self.remaining -= take as u64;
+        }
+        Ok(())
+    }
+}

--- a/crates/core/src/data/segment.rs
+++ b/crates/core/src/data/segment.rs
@@ -1,0 +1,168 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Unique shared data-segment writer.
+
+use std::num::NonZeroUsize;
+
+use opendal::Operator;
+use tokio::io::AsyncRead;
+
+use crate::Error;
+use crate::filesystem::ContentRef;
+use crate::format::{GcEpoch, ObjectClass, ObjectLocator, StreamKind};
+use crate::storage::{ImmutableWriter, finish_stream};
+
+/// Streaming writer for one immutable data segment.
+struct Writer {
+    writer: ImmutableWriter,
+    payload_length: u64,
+}
+
+/// Lazy sequence of immutable data segments rotated by payload target.
+pub struct DataSegmentWriter<'a> {
+    operator: &'a Operator,
+    gc_epoch: GcEpoch,
+    target_bytes: u64,
+    multipart_part_bytes: NonZeroUsize,
+    current: Option<Writer>,
+}
+
+impl<'a> DataSegmentWriter<'a> {
+    /// Create a segment placement session without opening a remote writer.
+    ///
+    /// `target_bytes` rotates shared segments and does not limit logical file
+    /// size.
+    pub const fn new(
+        operator: &'a Operator,
+        gc_epoch: GcEpoch,
+        target_bytes: u64,
+        multipart_part_bytes: NonZeroUsize,
+    ) -> Self {
+        Self {
+            operator,
+            gc_epoch,
+            target_bytes,
+            multipart_part_bytes,
+            current: None,
+        }
+    }
+
+    /// Append one independently verifiable stored byte stream.
+    pub async fn append(
+        &mut self,
+        source: &mut (impl AsyncRead + Unpin + ?Sized),
+    ) -> Result<(ObjectLocator, u64, ContentRef), Error> {
+        let segment = self.current_writer().await?;
+        let locator = segment.locator();
+        let (offset, content) = segment.append(source).await?;
+        Ok((locator, offset, content))
+    }
+
+    async fn current_writer(&mut self) -> Result<&mut Writer, Error> {
+        if self
+            .current
+            .as_ref()
+            .is_some_and(|segment| segment.payload_length() >= self.target_bytes)
+        {
+            self.current
+                .take()
+                .expect("current data segment exists")
+                .close()
+                .await?;
+        }
+        if self.current.is_none() {
+            self.current =
+                Some(Writer::open(self.operator, self.gc_epoch, self.multipart_part_bytes).await?);
+        }
+        Ok(self.current.as_mut().expect("data segment is open"))
+    }
+
+    pub const fn gc_epoch(&self) -> GcEpoch {
+        self.gc_epoch
+    }
+
+    /// Finish the current segment, if any.
+    pub async fn finish(&mut self) -> Result<(), Error> {
+        if let Some(segment) = self.current.take() {
+            segment.close().await?;
+        }
+        Ok(())
+    }
+
+    /// Abort the current incomplete segment, if any.
+    pub async fn abort(&mut self) {
+        if let Some(mut segment) = self.current.take() {
+            let _ = segment.abort().await;
+        }
+    }
+}
+
+impl Writer {
+    async fn open(
+        operator: &Operator,
+        gc_epoch: GcEpoch,
+        multipart_part_bytes: NonZeroUsize,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            writer: ImmutableWriter::open(
+                operator,
+                gc_epoch,
+                ObjectClass::DataSegment,
+                multipart_part_bytes,
+            )
+            .await?,
+            payload_length: 0,
+        })
+    }
+
+    async fn abort(&mut self) -> Result<(), Error> {
+        self.writer.abort().await
+    }
+
+    async fn append(
+        &mut self,
+        source: &mut (impl AsyncRead + Unpin + ?Sized),
+    ) -> Result<(u64, ContentRef), Error> {
+        let offset = self.payload_length;
+        let (length, digest) = self.writer.write_source(source).await?;
+        self.payload_length = self
+            .payload_length
+            .checked_add(length)
+            .ok_or_else(|| Error::invalid("write Managed data segment", "length overflows"))?;
+        Ok((offset, ContentRef::new(digest, length)))
+    }
+
+    fn locator(&self) -> ObjectLocator {
+        self.writer.locator()
+    }
+
+    const fn payload_length(&self) -> u64 {
+        self.payload_length
+    }
+
+    async fn close(self) -> Result<crate::format::StreamRef, Error> {
+        let digest = self.writer.digest();
+        finish_stream(
+            self.writer,
+            StreamKind::DATA_SEGMENT,
+            self.payload_length,
+            digest,
+        )
+        .await
+    }
+}

--- a/crates/core/src/data/write.rs
+++ b/crates/core/src/data/write.rs
@@ -1,0 +1,230 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Complete and range-hinted file publication.
+
+use std::num::NonZeroUsize;
+
+use opendal::Operator;
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite};
+
+use crate::Error;
+use crate::filesystem::ContentRef;
+use crate::format::{FileExtentMap, FileRange, GcEpoch};
+
+use super::DataAccess;
+use super::codec::ContentHasher;
+use super::extent::ExtentRunWriter;
+use super::lookup::ContentLookup;
+use super::partition::FilePartitioner;
+use super::segment::DataSegmentWriter;
+
+pub async fn publish_file<A: DataAccess, K: ContentLookup + ?Sized>(
+    access: &A,
+    operator: &Operator,
+    multipart_part_bytes: NonZeroUsize,
+    placement: &mut DataSegmentWriter<'_>,
+    source: &mut (dyn AsyncRead + Send + Unpin),
+    logical_bytes: u64,
+    known: &K,
+) -> Result<(ContentRef, FileExtentMap, bool), Error> {
+    let mut run = ExtentRunWriter::new(operator, placement.gc_epoch(), multipart_part_bytes);
+    let content = access
+        .partitioner()
+        .write_run(
+            access.codec(),
+            placement,
+            source,
+            known,
+            0,
+            logical_bytes,
+            &mut run,
+        )
+        .await?;
+    if let Some(reference) = known.file(content)? {
+        run.abort().await;
+        return Ok((content, reference, true));
+    }
+    let complete = content.length() != 0 && run.covers(FileRange::new(0, content.length())?);
+    let reference = match run.close().await? {
+        Some(run) if complete => FileExtentMap::from_base(run),
+        None if content.length() == 0 => FileExtentMap::empty(),
+        _ => {
+            return Err(Error::corrupt(
+                "publish Managed file",
+                "partitioned extents do not cover the source stream",
+            ));
+        }
+    };
+    Ok((content, reference, false))
+}
+
+pub async fn publish_file_patch<A: DataAccess, K: ContentLookup + ?Sized>(
+    access: &A,
+    operator: &Operator,
+    multipart_part_bytes: NonZeroUsize,
+    placement: &mut DataSegmentWriter<'_>,
+    source: &mut (dyn AsyncRead + Send + Unpin),
+    file_length: u64,
+    previous: (ContentRef, FileExtentMap),
+    ranges: &[FileRange],
+    known: &K,
+) -> Result<(ContentRef, FileExtentMap, bool), Error> {
+    if previous.0.length() > file_length {
+        return Err(Error::invalid(
+            "publish Managed file changes",
+            "trusted range publication does not support truncation",
+        ));
+    }
+    let mut content = ContentHasher::default();
+    let mut source = tokio_util::io::InspectReader::new(source, |bytes| content.observe(bytes));
+    let mut run = ExtentRunWriter::new(operator, placement.gc_epoch(), multipart_part_bytes);
+    let mut offset = 0_u64;
+    for range in ranges {
+        let end = range.end()?;
+        if range.offset < offset || end > file_length {
+            return Err(Error::invalid(
+                "publish Managed file changes",
+                "trusted ranges overlap, are out of order, or exceed the file",
+            ));
+        }
+        copy_exact(
+            &mut source,
+            range.offset - offset,
+            &mut tokio::io::sink(),
+            "scan unchanged Managed file range",
+        )
+        .await?;
+        let mut changed = (&mut source).take(range.length);
+        let content = access
+            .partitioner()
+            .write_run(
+                access.codec(),
+                placement,
+                &mut changed,
+                known,
+                range.offset,
+                range.length,
+                &mut run,
+            )
+            .await?;
+        if content.length() != range.length {
+            return Err(Error::conflict(
+                "publish Managed file changes",
+                "local file changed while publishing a trusted range",
+            ));
+        }
+        offset = end;
+    }
+    copy_exact(
+        &mut source,
+        file_length - offset,
+        &mut tokio::io::sink(),
+        "scan unchanged Managed file range",
+    )
+    .await?;
+    let mut extra = [0_u8; 1];
+    if source
+        .read(&mut extra)
+        .await
+        .map_err(|error| Error::io("finish Managed file scan", error))?
+        != 0
+    {
+        return Err(Error::conflict(
+            "publish Managed file changes",
+            "local file grew while it was being published",
+        ));
+    }
+    let content = content.complete_content().ok_or_else(|| {
+        Error::conflict(
+            "publish Managed file changes",
+            "local file was not read completely",
+        )
+    })?;
+    if content.length() != file_length {
+        return Err(Error::conflict(
+            "publish Managed file changes",
+            "local file length changed while it was being published",
+        ));
+    }
+    if let Some(data) = known.file(content)? {
+        run.abort().await;
+        return Ok((content, data, true));
+    }
+    if content == previous.0 {
+        run.abort().await;
+        return Ok((content, previous.1, true));
+    }
+    let replaces_file = ranges.len() == 1
+        && ranges[0].offset == 0
+        && ranges[0].length == file_length
+        && run.covers(ranges[0]);
+    let patch = run.close().await?.ok_or_else(|| {
+        Error::invalid(
+            "publish Managed file changes",
+            "changed content has no trusted changed range",
+        )
+    })?;
+    let data = if replaces_file {
+        FileExtentMap::from_base(patch)
+    } else {
+        super::extent::add_extent_run(
+            previous.1,
+            operator,
+            placement.gc_epoch(),
+            multipart_part_bytes,
+            patch,
+        )
+        .await?
+    };
+    Ok((content, data, false))
+}
+
+async fn copy_exact(
+    source: &mut (impl AsyncRead + Unpin),
+    length: u64,
+    destination: &mut (impl AsyncWrite + Unpin),
+    operation: &'static str,
+) -> Result<(), Error> {
+    let copied = tokio::io::copy(&mut source.take(length), destination)
+        .await
+        .map_err(|error| Error::io(operation, error))?;
+    if copied != length {
+        return Err(Error::conflict(
+            operation,
+            "local file changed while it was being published",
+        ));
+    }
+    Ok(())
+}
+
+pub fn data_segments<'a>(
+    operator: &'a Operator,
+    gc_epoch: GcEpoch,
+    target_bytes: u64,
+    multipart_part_bytes: NonZeroUsize,
+    stored_payload_bound: Option<u64>,
+) -> DataSegmentWriter<'a> {
+    let multipart_part_bytes = stored_payload_bound
+        .and_then(|bytes| bytes.checked_add(crate::format::STREAM_TAIL_BYTES as u64))
+        .and_then(|bytes| usize::try_from(bytes).ok())
+        .and_then(NonZeroUsize::new)
+        .map_or(multipart_part_bytes, |bytes| {
+            bytes.max(multipart_part_bytes)
+        });
+    DataSegmentWriter::new(operator, gc_epoch, target_bytes, multipart_part_bytes)
+}

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -75,6 +75,10 @@ impl Error {
         Self::new(ErrorKind::Conflict, operation, message)
     }
 
+    pub(crate) fn unsupported(operation: &'static str, message: impl Into<String>) -> Self {
+        Self::new(ErrorKind::Unsupported, operation, message)
+    }
+
     pub(crate) fn corrupt(operation: &'static str, message: impl Into<String>) -> Self {
         Self::new(ErrorKind::Corrupt, operation, message)
     }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,0 +1,174 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt;
+use std::path::Path;
+
+/// Stable failure categories based on the caller's next action.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    Invalid,
+    NotFound,
+    Unsupported,
+    PermissionDenied,
+    Conflict,
+    Corrupt,
+    Unavailable,
+}
+
+/// An OFS failure with a stable category and safe diagnostic context.
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+    operation: &'static str,
+    message: String,
+    context: Vec<(&'static str, String)>,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+impl Error {
+    pub fn new(kind: ErrorKind, operation: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            operation,
+            message: message.into(),
+            context: Vec::new(),
+            source: None,
+        }
+    }
+
+    pub const fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    pub fn with_context(mut self, key: &'static str, value: impl ToString) -> Self {
+        self.context.push((key, value.to_string()));
+        self
+    }
+
+    /// Attach the original implementation failure without changing its stable kind.
+    pub fn with_source(mut self, source: impl std::error::Error + Send + Sync + 'static) -> Self {
+        self.source = Some(Box::new(source));
+        self
+    }
+
+    pub(crate) fn invalid(operation: &'static str, message: impl Into<String>) -> Self {
+        Self::new(ErrorKind::Invalid, operation, message)
+    }
+
+    pub(crate) fn corrupt(operation: &'static str, message: impl Into<String>) -> Self {
+        Self::new(ErrorKind::Corrupt, operation, message)
+    }
+
+    pub(crate) fn from_io(
+        operation: &'static str,
+        path: Option<&Path>,
+        source: std::io::Error,
+    ) -> Self {
+        let kind = match source.kind() {
+            std::io::ErrorKind::NotFound => ErrorKind::NotFound,
+            std::io::ErrorKind::PermissionDenied => ErrorKind::PermissionDenied,
+            std::io::ErrorKind::AlreadyExists => ErrorKind::Conflict,
+            std::io::ErrorKind::Unsupported => ErrorKind::Unsupported,
+            _ => ErrorKind::Unavailable,
+        };
+        let mut error = Self::new(kind, operation, "local filesystem operation failed");
+        if let Some(path) = path {
+            error = error.with_context("path", path.display());
+        }
+        error.source = Some(Box::new(source));
+        error
+    }
+
+    pub(crate) fn io(operation: &'static str, source: std::io::Error) -> Self {
+        Self::from_io(operation, None, source)
+    }
+
+    pub(crate) fn from_storage(operation: &'static str, source: opendal::Error) -> Self {
+        let kind = match source.kind() {
+            opendal::ErrorKind::ConfigInvalid => ErrorKind::Invalid,
+            opendal::ErrorKind::Unsupported => ErrorKind::Unsupported,
+            opendal::ErrorKind::NotFound => ErrorKind::NotFound,
+            opendal::ErrorKind::PermissionDenied => ErrorKind::PermissionDenied,
+            opendal::ErrorKind::AlreadyExists | opendal::ErrorKind::ConditionNotMatch => {
+                ErrorKind::Conflict
+            }
+            _ => ErrorKind::Unavailable,
+        };
+        let message = match kind {
+            ErrorKind::Invalid => "object storage configuration is invalid",
+            ErrorKind::NotFound => "object storage entry does not exist",
+            ErrorKind::Unsupported => "object storage operation is unsupported",
+            ErrorKind::PermissionDenied => "object storage permission denied",
+            ErrorKind::Conflict => "object storage condition changed",
+            ErrorKind::Corrupt | ErrorKind::Unavailable => "object storage is unavailable",
+        };
+        let status = if source.is_temporary() {
+            "temporary"
+        } else if source.is_persistent() {
+            "persistent"
+        } else {
+            "permanent"
+        };
+        Self::new(kind, operation, message)
+            .with_context("storage_kind", source.kind())
+            .with_context("storage_status", status)
+            .with_source(source)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.operation, self.message)?;
+        if !self.context.is_empty() {
+            write!(formatter, " (")?;
+            for (index, (key, value)) in self.context.iter().enumerate() {
+                if index != 0 {
+                    write!(formatter, ", ")?;
+                }
+                write!(formatter, "{key}: {value}")?;
+            }
+            write!(formatter, ")")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_deref()
+            .map(|source| source as &(dyn std::error::Error + 'static))
+    }
+}
+
+impl From<ofs_managed_format::Error> for Error {
+    fn from(source: ofs_managed_format::Error) -> Self {
+        let kind = match source.kind() {
+            ofs_managed_format::ErrorKind::Invalid => ErrorKind::Invalid,
+            ofs_managed_format::ErrorKind::Unsupported => ErrorKind::Unsupported,
+            ofs_managed_format::ErrorKind::Corrupt => ErrorKind::Corrupt,
+            _ => ErrorKind::Corrupt,
+        };
+        let operation = source.operation();
+        let message = source.message().to_owned();
+        Self::new(kind, operation, message).with_source(source)
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -71,6 +71,10 @@ impl Error {
         Self::new(ErrorKind::Invalid, operation, message)
     }
 
+    pub(crate) fn conflict(operation: &'static str, message: impl Into<String>) -> Self {
+        Self::new(ErrorKind::Conflict, operation, message)
+    }
+
     pub(crate) fn corrupt(operation: &'static str, message: impl Into<String>) -> Self {
         Self::new(ErrorKind::Corrupt, operation, message)
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! OpenDAL-backed runtime primitives for the Managed v0 format.
+
+mod error;
+pub mod storage;
+
+pub use error::{Error, ErrorKind, Result};
+pub use ofs_managed_format::v0 as format;
+pub use ofs_managed_format::v0::model as filesystem;

--- a/crates/core/src/storage/control.rs
+++ b/crates/core/src/storage/control.rs
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Bounded control-object reads and conditional writes.
+
+use opendal::{ErrorKind as StorageErrorKind, Operator};
+use serde::{Serialize, de::DeserializeOwned};
+use std::marker::PhantomData;
+
+use crate::Error;
+use crate::format::codec::RecordCodec;
+
+/// One decoded mutable control value and its optional storage revision.
+pub struct ObservedControl<T> {
+    pub value: T,
+    pub revision: Option<String>,
+}
+
+/// Typed adapter for one bounded mutable control object.
+pub struct ControlRecord<T> {
+    key: &'static str,
+    codec: RecordCodec,
+    value: PhantomData<fn() -> T>,
+}
+
+impl<T> ControlRecord<T> {
+    /// Bind one wire codec to its only object key.
+    pub const fn new(key: &'static str, codec: RecordCodec) -> Self {
+        Self {
+            key,
+            codec,
+            value: PhantomData,
+        }
+    }
+}
+
+impl<T> ControlRecord<T>
+where
+    T: DeserializeOwned + Serialize,
+{
+    /// Read and decode one value together with its conditional revision.
+    pub async fn read(&self, operator: &Operator) -> Result<Option<ObservedControl<T>>, Error> {
+        let Some(object) = read_bounded(
+            operator,
+            self.key,
+            self.codec.maximum_encoded_bytes(),
+            "read Managed control object",
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(ObservedControl {
+            value: self.codec.decode(&object.bytes)?,
+            revision: object.revision,
+        }))
+    }
+
+    /// Encode and conditionally write one value.
+    pub async fn write(
+        &self,
+        operator: &Operator,
+        value: &T,
+        revision: Option<&str>,
+    ) -> Result<bool, Error> {
+        write_control(operator, self.key, self.codec.encode(value)?, revision).await
+    }
+}
+
+pub(super) struct BoundedObject {
+    pub(super) bytes: Vec<u8>,
+    revision: Option<String>,
+}
+
+pub(super) async fn read_bounded(
+    operator: &Operator,
+    key: &str,
+    maximum_bytes: usize,
+    operation: &'static str,
+) -> Result<Option<BoundedObject>, Error> {
+    let buffer = match operator.read(key).await {
+        Ok(buffer) => buffer,
+        Err(error) if error.kind() == StorageErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(Error::from_storage(operation, error)),
+    };
+    if buffer.len() > maximum_bytes {
+        return Err(Error::corrupt(operation, "object exceeds its size limit"));
+    }
+    let revision = match operator.stat(key).await {
+        Ok(metadata) => metadata.etag().map(str::to_owned),
+        Err(error) if error.kind() == StorageErrorKind::NotFound => None,
+        Err(error) if error.kind() == StorageErrorKind::Unsupported => None,
+        Err(error) => return Err(Error::from_storage(operation, error)),
+    };
+    Ok(Some(BoundedObject {
+        bytes: buffer.to_vec(),
+        revision,
+    }))
+}
+
+/// Conditionally replace one mutable control object.
+pub(super) async fn write_control(
+    operator: &Operator,
+    key: &str,
+    bytes: Vec<u8>,
+    revision: Option<&str>,
+) -> Result<bool, Error> {
+    let write = operator.write_with(key, bytes);
+    let result = match revision {
+        None => write.if_not_exists(true).await,
+        Some(revision) => write.if_match(revision).await,
+    };
+    match result {
+        Ok(_) => Ok(true),
+        Err(error)
+            if matches!(
+                error.kind(),
+                StorageErrorKind::AlreadyExists | StorageErrorKind::ConditionNotMatch
+            ) =>
+        {
+            Ok(false)
+        }
+        Err(error) => Err(Error::from_storage("publish Managed control object", error)),
+    }
+}

--- a/crates/core/src/storage/control.rs
+++ b/crates/core/src/storage/control.rs
@@ -17,6 +17,7 @@
 
 //! Bounded control-object reads and conditional writes.
 
+use futures::StreamExt as _;
 use opendal::{ErrorKind as StorageErrorKind, Operator};
 use serde::{Serialize, de::DeserializeOwned};
 use std::marker::PhantomData;
@@ -70,6 +71,22 @@ where
         }))
     }
 
+    /// Read one mutable control value, requiring a bound revision when replacement supports it.
+    pub async fn observe(&self, operator: &Operator) -> Result<Option<ObservedControl<T>>, Error> {
+        let observed = self.read(operator).await?;
+        if observed
+            .as_ref()
+            .is_some_and(|observed| observed.revision.is_none())
+            && operator.info().full_capability().write_with_if_match
+        {
+            return Err(Error::unsupported(
+                "observe Managed control object",
+                "storage does not return a revision with control reads",
+            ));
+        }
+        Ok(observed)
+    }
+
     /// Encode and conditionally write one value.
     pub async fn write(
         &self,
@@ -92,24 +109,44 @@ pub(super) async fn read_bounded(
     maximum_bytes: usize,
     operation: &'static str,
 ) -> Result<Option<BoundedObject>, Error> {
-    let buffer = match operator.read(key).await {
-        Ok(buffer) => buffer,
+    let reader = match operator.reader(key).await {
+        Ok(reader) => reader,
         Err(error) if error.kind() == StorageErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(Error::from_storage(operation, error)),
     };
-    if buffer.len() > maximum_bytes {
-        return Err(Error::corrupt(operation, "object exceeds its size limit"));
-    }
-    let revision = match operator.stat(key).await {
-        Ok(metadata) => metadata.etag().map(str::to_owned),
-        Err(error) if error.kind() == StorageErrorKind::NotFound => None,
-        Err(error) if error.kind() == StorageErrorKind::Unsupported => None,
+    let mut stream = match reader.into_stream(..).await {
+        Ok(stream) => stream,
+        Err(error) if error.kind() == StorageErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(Error::from_storage(operation, error)),
     };
-    Ok(Some(BoundedObject {
-        bytes: buffer.to_vec(),
-        revision,
-    }))
+    let (capacity, revision) = match stream.metadata().await {
+        Ok(metadata) => {
+            let length = usize::try_from(metadata.content_length())
+                .ok()
+                .filter(|length| *length <= maximum_bytes)
+                .ok_or_else(|| Error::corrupt(operation, "object exceeds its size limit"))?;
+            (length, metadata.etag().map(str::to_owned))
+        }
+        Err(error) if error.kind() == StorageErrorKind::NotFound => return Ok(None),
+        Err(error) if error.kind() == StorageErrorKind::Unsupported => (0, None),
+        Err(error) => return Err(Error::from_storage(operation, error)),
+    };
+
+    let mut bytes = Vec::with_capacity(capacity);
+    while let Some(buffer) = stream.next().await {
+        let buffer = match buffer {
+            Ok(buffer) => buffer,
+            Err(error) if error.kind() == StorageErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(Error::from_storage(operation, error)),
+        };
+        if buffer.len() > maximum_bytes - bytes.len() {
+            return Err(Error::corrupt(operation, "object exceeds its size limit"));
+        }
+        for chunk in buffer {
+            bytes.extend_from_slice(&chunk);
+        }
+    }
+    Ok(Some(BoundedObject { bytes, revision }))
 }
 
 /// Conditionally replace one mutable control object.

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! OpenDAL adapters for Managed control and immutable objects.
+
+mod control;
+mod object;
+mod record_stream;
+
+pub use control::{ControlRecord, ObservedControl};
+pub use object::{ImmutableWriter, read_immutable};
+pub use record_stream::{RecordStreamReader, RecordStreamWriter, finish_stream};

--- a/crates/core/src/storage/object.rs
+++ b/crates/core/src/storage/object.rs
@@ -1,0 +1,165 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Immutable object write and verified read.
+
+use blake3::Hasher;
+use opendal::{Buffer, Operator, Writer};
+use std::num::NonZeroUsize;
+use tokio::io::{AsyncRead, AsyncReadExt as _};
+
+use crate::Error;
+use crate::filesystem::Digest;
+use crate::format::{GcEpoch, ObjectClass, ObjectLocator, ObjectRef};
+
+use super::control::read_bounded;
+
+const SOURCE_BUFFER_BYTES: usize = 256 * 1024;
+
+pub struct ImmutableWriter {
+    operator: Operator,
+    locator: ObjectLocator,
+    writer: Writer,
+    hasher: Hasher,
+    encoded_length: u64,
+}
+
+impl ImmutableWriter {
+    pub async fn open(
+        operator: &Operator,
+        gc_epoch: GcEpoch,
+        class: ObjectClass,
+        multipart_part_bytes: NonZeroUsize,
+    ) -> Result<Self, Error> {
+        let locator = ObjectLocator::generate(gc_epoch, class);
+        let key = locator.key();
+        let writer = operator
+            .writer_with(&key)
+            .if_not_exists(true)
+            .chunk(multipart_part_bytes.get())
+            .await
+            .map_err(|error| Error::from_storage("open Managed object writer", error))?;
+        Ok(Self {
+            operator: operator.clone(),
+            locator,
+            writer,
+            hasher: Hasher::new(),
+            encoded_length: 0,
+        })
+    }
+
+    pub async fn write(&mut self, bytes: Vec<u8>) -> Result<(), Error> {
+        self.encoded_length = self
+            .encoded_length
+            .checked_add(bytes.len() as u64)
+            .ok_or_else(|| Error::invalid("write Managed object", "object length overflows"))?;
+        self.hasher.update(&bytes);
+        if let Err(error) = self.writer.write(Buffer::from(bytes)).await {
+            let error = Error::from_storage("write Managed object", error);
+            let _ = self.writer.abort().await;
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    pub fn locator(&self) -> ObjectLocator {
+        self.locator
+    }
+
+    pub fn digest(&self) -> Digest {
+        Digest::from_bytes(self.hasher.finalize().into())
+    }
+
+    pub async fn write_source<R>(&mut self, source: &mut R) -> Result<(u64, Digest), Error>
+    where
+        R: AsyncRead + Unpin + ?Sized,
+    {
+        let mut length = 0_u64;
+        let mut hasher = Hasher::new();
+        loop {
+            let mut bytes = vec![0; SOURCE_BUFFER_BYTES];
+            let read = match source.read(&mut bytes).await {
+                Ok(read) => read,
+                Err(error) => {
+                    let error = Error::from_io("read Managed object source", None, error);
+                    let _ = self.abort().await;
+                    return Err(error);
+                }
+            };
+            if read == 0 {
+                break;
+            }
+            bytes.truncate(read);
+            length = length
+                .checked_add(read as u64)
+                .ok_or_else(|| Error::invalid("write Managed object", "source length overflows"))?;
+            hasher.update(&bytes);
+            self.write(bytes).await?;
+        }
+        Ok((length, Digest::from_bytes(hasher.finalize().into())))
+    }
+
+    pub async fn abort(&mut self) -> Result<(), Error> {
+        self.writer
+            .abort()
+            .await
+            .map_err(|error| Error::from_storage("abort Managed object", error))
+    }
+
+    pub async fn close(mut self) -> Result<ObjectRef, Error> {
+        if let Err(error) = self.writer.close().await
+            && !self.published_object_is_visible().await
+        {
+            let _ = self.writer.abort().await;
+            return Err(Error::from_storage("finish Managed object", error));
+        }
+        Ok(ObjectRef {
+            locator: self.locator,
+            encoded_length: self.encoded_length,
+            digest: Digest::from_bytes(self.hasher.finalize().into()),
+        })
+    }
+
+    async fn published_object_is_visible(&self) -> bool {
+        self.operator
+            .stat(&self.locator.key())
+            .await
+            .is_ok_and(|metadata| metadata.content_length() == self.encoded_length)
+    }
+}
+
+pub async fn read_immutable(
+    operator: &Operator,
+    reference: ObjectRef,
+    maximum_bytes: usize,
+) -> Result<Vec<u8>, Error> {
+    let length = usize::try_from(reference.encoded_length)
+        .ok()
+        .filter(|length| *length <= maximum_bytes)
+        .ok_or_else(|| Error::corrupt("read Managed object", "object length is invalid"))?;
+    let bytes = read_bounded(operator, &reference.key(), length, "read Managed object")
+        .await?
+        .ok_or_else(|| Error::corrupt("read Managed object", "referenced object is missing"))?
+        .bytes;
+    if bytes.len() != length || blake3::hash(&bytes).as_bytes() != reference.digest.as_bytes() {
+        return Err(Error::corrupt(
+            "read Managed object",
+            "object does not match its reference",
+        ));
+    }
+    Ok(bytes)
+}

--- a/crates/core/src/storage/record_stream.rs
+++ b/crates/core/src/storage/record_stream.rs
@@ -193,6 +193,10 @@ impl RecordStreamWriter {
         let payload_digest = self.writer.digest();
         finish_stream(self.writer, self.kind, self.payload_length, payload_digest).await
     }
+
+    pub(crate) async fn abort(mut self) {
+        let _ = self.writer.abort().await;
+    }
 }
 
 pub async fn finish_stream(

--- a/crates/core/src/storage/record_stream.rs
+++ b/crates/core/src/storage/record_stream.rs
@@ -1,0 +1,259 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! OpenDAL adapter for Managed v0 record streams.
+
+use std::marker::PhantomData;
+use std::num::NonZeroUsize;
+
+use futures::AsyncReadExt as _;
+use opendal::Operator;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::Error;
+use crate::filesystem::Digest;
+use crate::format::{
+    GcEpoch, MAX_RECORD_FRAME_PAYLOAD_BYTES, ObjectClass, RECORD_FRAME_HEADER_BYTES,
+    STREAM_TAIL_BYTES, StreamKind, StreamRef, decode_record_frame_header, decode_stream_record,
+    encode_record_frame_header, encode_stream_record_into, encode_stream_tail,
+    validate_record_frame, validate_stream_tail,
+};
+
+use super::object::ImmutableWriter;
+
+pub struct RecordStreamReader<T> {
+    reference: StreamRef,
+    reader: opendal::FuturesAsyncReader,
+    object_hasher: blake3::Hasher,
+    offset: u64,
+    frame: Vec<u8>,
+    record_offset: usize,
+    records_remaining: u32,
+    completed: bool,
+    record: PhantomData<T>,
+}
+
+impl<T: DeserializeOwned> RecordStreamReader<T> {
+    pub async fn open(operator: &Operator, reference: StreamRef) -> Result<Self, Error> {
+        if reference
+            .payload_length
+            .checked_add(STREAM_TAIL_BYTES as u64)
+            != Some(reference.object.encoded_length)
+        {
+            return Err(Error::corrupt(
+                "read Managed stream",
+                "stream length does not match its reference",
+            ));
+        }
+        Ok(Self {
+            reference,
+            reader: open_payload_reader(operator, reference).await?,
+            object_hasher: blake3::Hasher::new(),
+            offset: 0,
+            frame: Vec::new(),
+            record_offset: 0,
+            records_remaining: 0,
+            completed: false,
+            record: PhantomData,
+        })
+    }
+
+    pub async fn next(&mut self) -> Result<Option<T>, Error> {
+        loop {
+            if self.records_remaining != 0 {
+                let record = decode_stream_record(&self.frame, &mut self.record_offset)?;
+                self.records_remaining -= 1;
+                return Ok(Some(record));
+            }
+            if !self.frame.is_empty() && self.record_offset != self.frame.len() {
+                return Err(Error::corrupt(
+                    "read Managed stream",
+                    "frame record count does not match its payload",
+                ));
+            }
+            if self.completed {
+                return Ok(None);
+            }
+            if self.offset == self.reference.payload_length {
+                if Digest::from_bytes(self.object_hasher.finalize().into())
+                    != self.reference.payload_digest
+                {
+                    return Err(Error::corrupt(
+                        "read Managed stream",
+                        "stream payload does not match its reference",
+                    ));
+                }
+                let mut tail = [0_u8; STREAM_TAIL_BYTES];
+                self.reader
+                    .read_exact(&mut tail)
+                    .await
+                    .map_err(|error| Error::io("read Managed stream tail", error))?;
+                self.object_hasher.update(&tail);
+                validate_stream_tail(self.reference, &tail)?;
+                if Digest::from_bytes(self.object_hasher.finalize().into())
+                    != self.reference.object.digest
+                {
+                    return Err(Error::corrupt(
+                        "read Managed stream",
+                        "object does not match its reference",
+                    ));
+                }
+                self.completed = true;
+                return Ok(None);
+            }
+            let (end, record_count) = read_next_frame(
+                &mut self.reader,
+                self.reference,
+                self.offset,
+                &mut self.frame,
+            )
+            .await?;
+            self.object_hasher.update(&self.frame);
+            self.record_offset = RECORD_FRAME_HEADER_BYTES;
+            self.records_remaining = record_count;
+            self.offset = end;
+        }
+    }
+}
+
+pub struct RecordStreamWriter {
+    writer: ImmutableWriter,
+    kind: StreamKind,
+    payload_length: u64,
+    frame: Vec<u8>,
+    record: Vec<u8>,
+    frame_records: u32,
+}
+
+impl RecordStreamWriter {
+    pub async fn open(
+        operator: &Operator,
+        gc_epoch: GcEpoch,
+        class: ObjectClass,
+        kind: StreamKind,
+        multipart_part_bytes: NonZeroUsize,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            writer: ImmutableWriter::open(operator, gc_epoch, class, multipart_part_bytes).await?,
+            kind,
+            payload_length: 0,
+            frame: Vec::new(),
+            record: Vec::new(),
+            frame_records: 0,
+        })
+    }
+
+    pub async fn write(&mut self, record: &impl Serialize) -> Result<(), Error> {
+        encode_stream_record_into(record, &mut self.record)?;
+        if !self.frame.is_empty()
+            && self.frame.len().saturating_add(self.record.len()) > MAX_RECORD_FRAME_PAYLOAD_BYTES
+        {
+            self.flush_frame().await?;
+        }
+        self.frame.extend_from_slice(&self.record);
+        self.frame_records = self.frame_records.checked_add(1).ok_or_else(|| {
+            Error::invalid("write Managed stream", "frame record count overflows")
+        })?;
+        Ok(())
+    }
+
+    async fn flush_frame(&mut self) -> Result<(), Error> {
+        if self.frame_records == 0 {
+            return Ok(());
+        }
+        let header = encode_record_frame_header(self.frame_records, &self.frame)?;
+        let frame_length = header.len() + self.frame.len();
+        self.payload_length = self
+            .payload_length
+            .checked_add(frame_length as u64)
+            .ok_or_else(|| Error::invalid("write Managed stream", "payload length overflows"))?;
+        self.writer.write(header.to_vec()).await?;
+        self.writer.write(std::mem::take(&mut self.frame)).await?;
+        self.frame_records = 0;
+        Ok(())
+    }
+
+    pub async fn close(mut self) -> Result<StreamRef, Error> {
+        self.flush_frame().await?;
+        let payload_digest = self.writer.digest();
+        finish_stream(self.writer, self.kind, self.payload_length, payload_digest).await
+    }
+}
+
+pub async fn finish_stream(
+    mut writer: ImmutableWriter,
+    kind: StreamKind,
+    payload_length: u64,
+    digest: Digest,
+) -> Result<StreamRef, Error> {
+    let tail = encode_stream_tail(kind, payload_length, digest)?;
+    writer.write(tail).await?;
+    let object = writer.close().await?;
+    Ok(StreamRef {
+        kind,
+        object,
+        payload_length,
+        payload_digest: digest,
+    })
+}
+
+async fn open_payload_reader(
+    operator: &Operator,
+    reference: StreamRef,
+) -> Result<opendal::FuturesAsyncReader, Error> {
+    operator
+        .reader_with(&reference.object.key())
+        .content_length_hint(reference.object.encoded_length)
+        .await
+        .map_err(|error| Error::from_storage("read Managed stream", error))?
+        .into_futures_async_read(0..reference.object.encoded_length)
+        .await
+        .map_err(|error| Error::from_storage("read Managed stream", error))
+}
+
+async fn read_next_frame(
+    reader: &mut opendal::FuturesAsyncReader,
+    reference: StreamRef,
+    offset: u64,
+    frame: &mut Vec<u8>,
+) -> Result<(u64, u32), Error> {
+    let header_end = offset
+        .checked_add(RECORD_FRAME_HEADER_BYTES as u64)
+        .filter(|end| *end <= reference.payload_length)
+        .ok_or_else(|| Error::corrupt("read Managed stream", "frame header is truncated"))?;
+    let mut header = [0_u8; RECORD_FRAME_HEADER_BYTES];
+    reader
+        .read_exact(&mut header)
+        .await
+        .map_err(|error| Error::io("read Managed stream", error))?;
+    let payload_length = decode_record_frame_header(&header)?;
+    let payload_end = header_end
+        .checked_add(payload_length as u64)
+        .filter(|end| *end <= reference.payload_length)
+        .ok_or_else(|| Error::corrupt("read Managed stream", "frame payload is truncated"))?;
+    frame.clear();
+    frame.reserve(RECORD_FRAME_HEADER_BYTES + payload_length);
+    frame.extend_from_slice(&header);
+    frame.resize(RECORD_FRAME_HEADER_BYTES + payload_length, 0);
+    reader
+        .read_exact(&mut frame[RECORD_FRAME_HEADER_BYTES..])
+        .await
+        .map_err(|error| Error::io("read Managed stream", error))?;
+    let record_count = validate_record_frame(frame)?;
+    Ok((payload_end, record_count))
+}

--- a/crates/core/tests/data_segment.rs
+++ b/crates/core/tests/data_segment.rs
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::num::NonZeroUsize;
+
+use ofs_core::data::{DataSegmentWriter, RangeReader};
+use ofs_core::format::GcEpoch;
+use opendal::Operator;
+use opendal::services::Memory;
+
+fn memory_operator() -> Operator {
+    Operator::new(Memory::default())
+        .expect("memory service configuration is valid")
+        .finish()
+}
+
+#[tokio::test]
+async fn round_trips_verified_segment_ranges() {
+    let operator = memory_operator();
+    let expected = b"streamed Managed data";
+    let mut source = expected.as_slice();
+    let mut segments = DataSegmentWriter::new(
+        &operator,
+        GcEpoch::ZERO,
+        1024,
+        NonZeroUsize::new(1024).unwrap(),
+    );
+    let (locator, offset, content) = segments.append(&mut source).await.unwrap();
+    segments.finish().await.unwrap();
+
+    let mut reader = RangeReader::open(&operator, locator, offset..offset + content.length())
+        .await
+        .unwrap();
+    let mut actual = Vec::new();
+    reader.copy_file(content, &mut actual).await.unwrap();
+
+    assert_eq!(actual, expected);
+}

--- a/crates/core/tests/file_data.rs
+++ b/crates/core/tests/file_data.rs
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::num::NonZeroUsize;
+
+use ofs_core::Result;
+use ofs_core::data::{
+    ContentLookup, CoreDataAccess, DataSegmentWriter, publish_file, restore_file,
+};
+use ofs_core::filesystem::ContentRef;
+use ofs_core::format::{ExtentRef, FileExtentMap, GcEpoch};
+use opendal::Operator;
+use opendal::services::Memory;
+
+struct NoReachableContent;
+
+impl ContentLookup for NoReachableContent {
+    fn file(&self, _content: ContentRef) -> Result<Option<FileExtentMap>> {
+        Ok(None)
+    }
+
+    fn extent(&self, _content: ContentRef) -> Result<Option<ExtentRef>> {
+        Ok(None)
+    }
+}
+
+fn memory_operator() -> Operator {
+    Operator::new(Memory::default())
+        .expect("memory service configuration is valid")
+        .finish()
+}
+
+#[tokio::test]
+async fn publishes_and_restores_whole_identity_files() -> Result<()> {
+    let operator = memory_operator();
+    let access = CoreDataAccess::default();
+    let expected = b"one canonical file-data pipeline";
+    let mut source = expected.as_slice();
+    let part_bytes = NonZeroUsize::new(1024).unwrap();
+    let mut segments = DataSegmentWriter::new(&operator, GcEpoch::ZERO, 1024, part_bytes);
+
+    let (content, reference, reused) = publish_file(
+        &access,
+        &operator,
+        part_bytes,
+        &mut segments,
+        &mut source,
+        expected.len() as u64,
+        &NoReachableContent,
+    )
+    .await?;
+    segments.finish().await?;
+    assert!(!reused);
+
+    let mut actual = Vec::new();
+    restore_file(
+        &access,
+        &operator,
+        0,
+        1024,
+        reference,
+        content,
+        0..content.length(),
+        None,
+        &mut actual,
+    )
+    .await?;
+    assert_eq!(actual, expected);
+    Ok(())
+}

--- a/crates/core/tests/file_data.rs
+++ b/crates/core/tests/file_data.rs
@@ -19,9 +19,9 @@ use std::num::NonZeroUsize;
 
 use ofs_core::Result;
 use ofs_core::data::{
-    ContentLookup, CoreDataAccess, DataSegmentWriter, publish_file, restore_file,
+    ContentLookup, CoreDataAccess, DataSegmentWriter, ReusableFile, publish_file, restore_file,
 };
-use ofs_core::filesystem::ContentRef;
+use ofs_core::filesystem::{ContentRef, Digest};
 use ofs_core::format::{ExtentRef, FileExtentMap, GcEpoch};
 use opendal::Operator;
 use opendal::services::Memory;
@@ -80,5 +80,118 @@ async fn publishes_and_restores_whole_identity_files() -> Result<()> {
     )
     .await?;
     assert_eq!(actual, expected);
+    Ok(())
+}
+
+#[tokio::test]
+async fn rejects_a_full_restore_with_the_wrong_file_identity() -> Result<()> {
+    let operator = memory_operator();
+    let access = CoreDataAccess::default();
+    let expected = b"extent bytes with a mismatched file identity";
+    let mut source = expected.as_slice();
+    let part_bytes = NonZeroUsize::new(1024).unwrap();
+    let mut segments = DataSegmentWriter::new(&operator, GcEpoch::ZERO, 1024, part_bytes);
+
+    let (content, mut reference, _) = publish_file(
+        &access,
+        &operator,
+        part_bytes,
+        &mut segments,
+        &mut source,
+        expected.len() as u64,
+        &NoReachableContent,
+    )
+    .await?;
+    segments.finish().await?;
+
+    reference.patch_levels.push(reference.base_run.clone());
+    let mismatched = ContentRef::new(Digest::from_bytes([0; 32]), content.length());
+    let mut actual = Vec::new();
+    let error = restore_file(
+        &access,
+        &operator,
+        0,
+        1024,
+        reference,
+        mismatched,
+        0..mismatched.length(),
+        None,
+        &mut actual,
+    )
+    .await
+    .expect_err("a complete restore must verify the file content reference");
+
+    assert_eq!(error.kind(), ofs_core::ErrorKind::Corrupt);
+    assert_eq!(actual, expected);
+    Ok(())
+}
+
+#[tokio::test]
+async fn verifies_an_empty_file_identity() {
+    let operator = memory_operator();
+    let access = CoreDataAccess::default();
+    let content = ContentRef::new(Digest::from_bytes([0; 32]), 0);
+    let mut actual = Vec::new();
+
+    let error = restore_file(
+        &access,
+        &operator,
+        0,
+        1024,
+        FileExtentMap::empty(),
+        content,
+        0..0,
+        None,
+        &mut actual,
+    )
+    .await
+    .expect_err("an empty restore must verify the empty content digest");
+
+    assert_eq!(error.kind(), ofs_core::ErrorKind::Corrupt);
+    assert!(actual.is_empty());
+}
+
+#[tokio::test]
+async fn verifies_reused_bytes_during_a_full_restore() -> Result<()> {
+    let operator = memory_operator();
+    let access = CoreDataAccess::default();
+    let expected = b"remote content whose placement is reusable";
+    let mut source = expected.as_slice();
+    let part_bytes = NonZeroUsize::new(1024).unwrap();
+    let mut segments = DataSegmentWriter::new(&operator, GcEpoch::ZERO, 1024, part_bytes);
+
+    let (content, reference, _) = publish_file(
+        &access,
+        &operator,
+        part_bytes,
+        &mut segments,
+        &mut source,
+        expected.len() as u64,
+        &NoReachableContent,
+    )
+    .await?;
+    segments.finish().await?;
+
+    let mut stale = std::io::Cursor::new(vec![b'x'; expected.len()]);
+    let mut actual = Vec::new();
+    let error = restore_file(
+        &access,
+        &operator,
+        0,
+        1024,
+        reference.clone(),
+        content,
+        0..content.length(),
+        Some(ReusableFile {
+            reference,
+            source: &mut stale,
+        }),
+        &mut actual,
+    )
+    .await
+    .expect_err("a complete restore must verify bytes copied from a reusable file");
+
+    assert_eq!(error.kind(), ofs_core::ErrorKind::Corrupt);
+    assert_eq!(actual, vec![b'x'; expected.len()]);
     Ok(())
 }

--- a/crates/core/tests/storage.rs
+++ b/crates/core/tests/storage.rs
@@ -16,11 +16,118 @@
 // under the License.
 
 use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
+use ofs_core::ErrorKind;
 use ofs_core::format::{GcEpoch, ObjectClass, RecordCodec, StreamKind};
 use ofs_core::storage::{ControlRecord, RecordStreamReader, RecordStreamWriter};
-use opendal::Operator;
+use opendal::raw::*;
 use opendal::services::Memory;
+use opendal::{EntryMode, Metadata, Operator};
+
+#[derive(Clone, Debug)]
+struct MismatchedStatLayer {
+    armed: Arc<AtomicBool>,
+    body_reads: Arc<AtomicUsize>,
+    stat_calls: Arc<AtomicUsize>,
+    suppress_read_metadata: bool,
+}
+
+#[derive(Debug)]
+struct MismatchedStatAccess<A> {
+    inner: A,
+    armed: Arc<AtomicBool>,
+    body_reads: Arc<AtomicUsize>,
+    stat_calls: Arc<AtomicUsize>,
+    suppress_read_metadata: bool,
+}
+
+#[derive(Debug)]
+struct ReadProbe<R> {
+    inner: R,
+    body_reads: Arc<AtomicUsize>,
+}
+
+impl<R: oio::Read> oio::Read for ReadProbe<R> {
+    async fn read(&mut self) -> opendal::Result<opendal::Buffer> {
+        self.body_reads.fetch_add(1, Ordering::SeqCst);
+        self.inner.read().await
+    }
+}
+
+impl<A: Access> Layer<A> for MismatchedStatLayer {
+    type LayeredAccess = MismatchedStatAccess<A>;
+
+    fn layer(&self, inner: A) -> Self::LayeredAccess {
+        MismatchedStatAccess {
+            inner,
+            armed: self.armed.clone(),
+            body_reads: self.body_reads.clone(),
+            stat_calls: self.stat_calls.clone(),
+            suppress_read_metadata: self.suppress_read_metadata,
+        }
+    }
+}
+
+impl<A: Access> LayeredAccess for MismatchedStatAccess<A> {
+    type Inner = A;
+    type Reader = ReadProbe<A::Reader>;
+    type Writer = A::Writer;
+    type Lister = A::Lister;
+    type Deleter = A::Deleter;
+    type Copier = A::Copier;
+
+    fn inner(&self) -> &Self::Inner {
+        &self.inner
+    }
+
+    async fn read(&self, path: &str, args: OpRead) -> opendal::Result<(RpRead, Self::Reader)> {
+        let (response, reader) = self.inner.read(path, args).await?;
+        let response = if self.suppress_read_metadata {
+            RpRead::default()
+        } else if self.armed.load(Ordering::SeqCst) {
+            let metadata = response
+                .into_metadata()
+                .unwrap_or_else(|| Metadata::new(EntryMode::FILE))
+                .with_etag("\"revision-from-read\"".to_owned());
+            RpRead::new(metadata)
+        } else {
+            response
+        };
+        Ok((
+            response,
+            ReadProbe {
+                inner: reader,
+                body_reads: self.body_reads.clone(),
+            },
+        ))
+    }
+
+    async fn write(&self, path: &str, args: OpWrite) -> opendal::Result<(RpWrite, Self::Writer)> {
+        self.inner.write(path, args).await
+    }
+
+    async fn stat(&self, path: &str, args: OpStat) -> opendal::Result<RpStat> {
+        self.stat_calls.fetch_add(1, Ordering::SeqCst);
+        let response = self.inner.stat(path, args).await?;
+        if self.armed.swap(false, Ordering::SeqCst) {
+            Ok(response.map_metadata(|metadata| {
+                metadata.with_etag("\"revision-from-another-value\"".to_owned())
+            }))
+        } else {
+            Ok(response)
+        }
+    }
+
+    async fn delete(&self) -> opendal::Result<(RpDelete, Self::Deleter)> {
+        self.inner.delete().await
+    }
+
+    async fn list(&self, path: &str, args: OpList) -> opendal::Result<(RpList, Self::Lister)> {
+        self.inner.list(path, args).await
+    }
+}
 
 fn memory_operator() -> Operator {
     Operator::new(Memory::default())
@@ -47,8 +154,137 @@ async fn conditionally_publishes_control_records() {
             .unwrap()
     );
 
-    let observed = RECORD.read(&operator).await.unwrap().unwrap();
+    let observed = RECORD.observe(&operator).await.unwrap().unwrap();
     assert_eq!(observed.value, "first");
+}
+
+#[tokio::test]
+async fn binds_control_bytes_to_their_conditional_revision() {
+    const RECORD: ControlRecord<String> = ControlRecord::new(
+        "managed/0/test/bound-head",
+        RecordCodec::new(*b"OFSTEST0", 1024),
+    );
+    let armed = Arc::new(AtomicBool::new(false));
+    let body_reads = Arc::new(AtomicUsize::new(0));
+    let stat_calls = Arc::new(AtomicUsize::new(0));
+    let operator = Operator::new(Memory::default())
+        .expect("memory service configuration is valid")
+        .layer(MismatchedStatLayer {
+            armed: armed.clone(),
+            body_reads: body_reads.clone(),
+            stat_calls: stat_calls.clone(),
+            suppress_read_metadata: false,
+        })
+        .finish();
+
+    assert!(
+        RECORD
+            .write(&operator, &"first".to_owned(), None)
+            .await
+            .unwrap()
+    );
+    armed.store(true, Ordering::SeqCst);
+
+    let observed = RECORD.observe(&operator).await.unwrap().unwrap();
+    assert_eq!(observed.value, "first");
+    assert_eq!(observed.revision.as_deref(), Some("\"revision-from-read\""));
+    assert_eq!(stat_calls.load(Ordering::SeqCst), 0);
+    assert!(body_reads.load(Ordering::SeqCst) > 0);
+}
+
+#[tokio::test]
+async fn rejects_an_oversized_control_record_before_reading_its_body() {
+    const KEY: &str = "managed/0/test/oversized-head";
+    const CODEC: RecordCodec = RecordCodec::new(*b"OFSTEST0", 32);
+    const RECORD: ControlRecord<String> = ControlRecord::new(KEY, CODEC);
+    let armed = Arc::new(AtomicBool::new(false));
+    let body_reads = Arc::new(AtomicUsize::new(0));
+    let stat_calls = Arc::new(AtomicUsize::new(0));
+    let operator = Operator::new(Memory::default())
+        .expect("memory service configuration is valid")
+        .layer(MismatchedStatLayer {
+            armed,
+            body_reads: body_reads.clone(),
+            stat_calls: stat_calls.clone(),
+            suppress_read_metadata: false,
+        })
+        .finish();
+    operator
+        .write(KEY, vec![0; CODEC.maximum_encoded_bytes() + 1])
+        .await
+        .unwrap();
+
+    let error = match RECORD.read(&operator).await {
+        Ok(_) => panic!("read metadata must reject an oversized object"),
+        Err(error) => error,
+    };
+
+    assert_eq!(error.kind(), ErrorKind::Corrupt);
+    assert_eq!(stat_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(body_reads.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn keeps_the_streaming_size_limit_without_read_metadata() {
+    const KEY: &str = "managed/0/test/unreported-oversized-head";
+    const CODEC: RecordCodec = RecordCodec::new(*b"OFSTEST0", 32);
+    const RECORD: ControlRecord<String> = ControlRecord::new(KEY, CODEC);
+    let body_reads = Arc::new(AtomicUsize::new(0));
+    let stat_calls = Arc::new(AtomicUsize::new(0));
+    let operator = Operator::new(Memory::default())
+        .expect("memory service configuration is valid")
+        .layer(MismatchedStatLayer {
+            armed: Arc::new(AtomicBool::new(false)),
+            body_reads: body_reads.clone(),
+            stat_calls: stat_calls.clone(),
+            suppress_read_metadata: true,
+        })
+        .finish();
+    operator
+        .write(KEY, vec![0; CODEC.maximum_encoded_bytes() + 1])
+        .await
+        .unwrap();
+
+    let error = match RECORD.read(&operator).await {
+        Ok(_) => panic!("the streaming limit must reject an oversized object"),
+        Err(error) => error,
+    };
+
+    assert_eq!(error.kind(), ErrorKind::Corrupt);
+    assert_eq!(stat_calls.load(Ordering::SeqCst), 0);
+    assert!(body_reads.load(Ordering::SeqCst) > 0);
+}
+
+#[tokio::test]
+async fn reads_bounded_objects_without_read_metadata() {
+    const RECORD: ControlRecord<String> = ControlRecord::new(
+        "managed/0/test/unreported-head",
+        RecordCodec::new(*b"OFSTEST0", 1024),
+    );
+    let body_reads = Arc::new(AtomicUsize::new(0));
+    let stat_calls = Arc::new(AtomicUsize::new(0));
+    let operator = Operator::new(Memory::default())
+        .expect("memory service configuration is valid")
+        .layer(MismatchedStatLayer {
+            armed: Arc::new(AtomicBool::new(false)),
+            body_reads: body_reads.clone(),
+            stat_calls: stat_calls.clone(),
+            suppress_read_metadata: true,
+        })
+        .finish();
+    assert!(
+        RECORD
+            .write(&operator, &"value".to_owned(), None)
+            .await
+            .unwrap()
+    );
+
+    let observed = RECORD.read(&operator).await.unwrap().unwrap();
+
+    assert_eq!(observed.value, "value");
+    assert_eq!(observed.revision, None);
+    assert_eq!(stat_calls.load(Ordering::SeqCst), 0);
+    assert!(body_reads.load(Ordering::SeqCst) > 0);
 }
 
 #[tokio::test]

--- a/crates/core/tests/storage.rs
+++ b/crates/core/tests/storage.rs
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::num::NonZeroUsize;
+
+use ofs_core::format::{GcEpoch, ObjectClass, RecordCodec, StreamKind};
+use ofs_core::storage::{ControlRecord, RecordStreamReader, RecordStreamWriter};
+use opendal::Operator;
+use opendal::services::Memory;
+
+fn memory_operator() -> Operator {
+    Operator::new(Memory::default())
+        .expect("memory service configuration is valid")
+        .finish()
+}
+
+#[tokio::test]
+async fn conditionally_publishes_control_records() {
+    const RECORD: ControlRecord<String> =
+        ControlRecord::new("managed/0/test/head", RecordCodec::new(*b"OFSTEST0", 1024));
+    let operator = memory_operator();
+
+    assert!(
+        RECORD
+            .write(&operator, &"first".to_owned(), None)
+            .await
+            .unwrap()
+    );
+    assert!(
+        !RECORD
+            .write(&operator, &"stale".to_owned(), None)
+            .await
+            .unwrap()
+    );
+
+    let observed = RECORD.read(&operator).await.unwrap().unwrap();
+    assert_eq!(observed.value, "first");
+}
+
+#[tokio::test]
+async fn streams_records_through_immutable_objects() {
+    let operator = memory_operator();
+    let mut writer = RecordStreamWriter::open(
+        &operator,
+        GcEpoch::ZERO,
+        ObjectClass::NamespaceSegment,
+        StreamKind::NAMESPACE_SNAPSHOT,
+        NonZeroUsize::new(1024).unwrap(),
+    )
+    .await
+    .unwrap();
+    writer.write(&"alpha").await.unwrap();
+    writer.write(&"beta").await.unwrap();
+    let reference = writer.close().await.unwrap();
+
+    let mut reader = RecordStreamReader::<String>::open(&operator, reference)
+        .await
+        .unwrap();
+    assert_eq!(reader.next().await.unwrap().as_deref(), Some("alpha"));
+    assert_eq!(reader.next().await.unwrap().as_deref(), Some("beta"));
+    assert_eq!(reader.next().await.unwrap(), None);
+}


### PR DESCRIPTION
This PR adds storage and file data access for the managed v0 format.

It uses OpenDAL for control records, immutable objects, and record streams. The data pipeline partitions files, writes data segments, resolves extents, and restores logical ranges. Volume state and sync behavior are out of scope.

Depends on #29. Part of #26.

Parts of this PR were written with AI assistance. I reviewed the code and take responsibility for it.

## Validation

- `cargo x lint`
- `cargo x check`
- `cargo x test`
- `cargo x licenses`
