### PR TITLE
feat: add managed volume lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,7 @@ dependencies = [
  "serde",
  "tokio",
  "tokio-util",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,10 +1098,12 @@ name = "ofs-core"
 version = "0.0.24"
 dependencies = [
  "blake3",
+ "ciborium",
  "futures",
  "ofs-managed-format",
  "opendal",
  "serde",
+ "tempfile",
  "tokio",
  "tokio-util",
  "uuid",
@@ -1144,6 +1146,7 @@ dependencies = [
  "opendal-layer-logging",
  "opendal-layer-retry",
  "opendal-layer-timeout",
+ "opendal-service-fs",
 ]
 
 [[package]]
@@ -1215,6 +1218,20 @@ checksum = "1e91f731724c213af81e9d03517859c8fc47b4578e64ad61ae4f099f10fe36e3"
 dependencies = [
  "opendal-core",
  "tokio",
+]
+
+[[package]]
+name = "opendal-service-fs"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e89a665fef0e6bd249cf5ea47fc174b7ba892159bee4b9382528b1ca873a2c"
+dependencies = [
+ "bytes",
+ "log",
+ "opendal-core",
+ "serde",
+ "tokio",
+ "xattr",
 ]
 
 [[package]]
@@ -2273,6 +2290,16 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "which",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -27,15 +27,18 @@ version = "0.0.24"
 
 [dependencies]
 blake3.workspace = true
+ciborium = "0.2"
 futures.workspace = true
 ofs-managed-format = { path = "../managed-format" }
 opendal = "0.57.0"
 serde = { version = "1", features = ["derive"] }
+tempfile = "3"
 tokio = { version = "1", features = ["io-util"] }
 tokio-util.workspace = true
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
+opendal = { version = "0.57.0", features = ["services-fs"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -33,6 +33,7 @@ opendal = "0.57.0"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["io-util"] }
 tokio-util.workspace = true
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/core/src/authority/mod.rs
+++ b/crates/core/src/authority/mod.rs
@@ -1,0 +1,124 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Core namespace authority and its extension boundary.
+
+mod object;
+
+use std::fmt;
+use std::future::Future;
+use std::num::NonZeroUsize;
+
+use opendal::Operator;
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+use crate::format::{ExtensionDescriptor, GcEpoch};
+
+pub use crate::format::AuthorityHead;
+pub use object::DefaultAuthorityAccess;
+
+pub const DEFAULT_AUTHORITY: &str = "main";
+
+/// Stable identity of one namespace authority.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct AuthorityId([u8; 16]);
+
+impl AuthorityId {
+    pub fn generate() -> Self {
+        Self(*uuid::Uuid::new_v4().as_bytes())
+    }
+
+    pub const fn from_bytes(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    pub const fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+}
+
+/// One observed authority position and its opaque conditional revision.
+#[derive(Clone, Debug)]
+pub struct AuthorityObservation {
+    pub id: AuthorityId,
+    pub head: AuthorityHead,
+    pub revision: Vec<u8>,
+}
+
+/// One live root consumed and replaced during collection.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AuthorityRoot {
+    pub id: AuthorityId,
+    pub name: String,
+    pub head: AuthorityHead,
+}
+
+/// Opaque fence established before collection roots are streamed.
+#[derive(Clone, Debug)]
+pub struct CollectionFence {
+    pub epoch: GcEpoch,
+    pub revision: Vec<u8>,
+}
+
+/// Forward-only stream of authority roots.
+pub type AuthorityRoots = futures::stream::BoxStream<'static, Result<AuthorityRoot, Error>>;
+
+/// Namespace authority access.
+///
+/// The core implementation always owns `main`. Authority extensions wrap an
+/// existing implementation, delegate its authorities unchanged, and add their
+/// own names and collection roots.
+pub trait AuthorityAccess: Send + Sync + fmt::Debug + Unpin + 'static {
+    fn info(&self) -> Option<ExtensionDescriptor>;
+
+    fn initialize<'a>(
+        &'a self,
+        operator: &'a Operator,
+        multipart_part_bytes: NonZeroUsize,
+        initial: AuthorityHead,
+    ) -> impl Future<Output = Result<(), Error>> + Send + 'a;
+
+    fn observe<'a>(
+        &'a self,
+        operator: &'a Operator,
+        name: &'a str,
+    ) -> impl Future<Output = Result<AuthorityObservation, Error>> + Send + 'a;
+
+    fn compare_exchange<'a>(
+        &'a self,
+        operator: &'a Operator,
+        multipart_part_bytes: NonZeroUsize,
+        name: &'a str,
+        observed: &'a AuthorityObservation,
+        next: AuthorityHead,
+    ) -> impl Future<Output = Result<bool, Error>> + Send + 'a;
+
+    fn begin_collection<'a>(
+        &'a self,
+        operator: &'a Operator,
+        multipart_part_bytes: NonZeroUsize,
+    ) -> impl Future<Output = Result<(CollectionFence, AuthorityRoots), Error>> + Send + 'a;
+
+    fn finish_collection<'a>(
+        &'a self,
+        operator: &'a Operator,
+        multipart_part_bytes: NonZeroUsize,
+        fence: CollectionFence,
+        roots: &'a mut AuthorityRoots,
+    ) -> impl Future<Output = Result<bool, Error>> + Send + 'a;
+}

--- a/crates/core/src/authority/object.rs
+++ b/crates/core/src/authority/object.rs
@@ -1,0 +1,189 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Object-backed default authority store.
+
+use std::num::NonZeroUsize;
+
+use futures::{StreamExt as _, TryStreamExt as _};
+use opendal::Operator;
+
+use crate::Error;
+use crate::format::{AUTHORITY_HEAD_KEY, AUTHORITY_HEAD_RECORD, ExtensionDescriptor};
+use crate::storage::ControlRecord;
+
+use super::{
+    AuthorityAccess, AuthorityHead, AuthorityId, AuthorityObservation, AuthorityRoot,
+    AuthorityRoots, CollectionFence, DEFAULT_AUTHORITY,
+};
+
+const HEAD_RECORD: ControlRecord<AuthorityHead> =
+    ControlRecord::new(AUTHORITY_HEAD_KEY, AUTHORITY_HEAD_RECORD);
+
+/// Core single-authority implementation.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DefaultAuthorityAccess;
+
+impl AuthorityAccess for DefaultAuthorityAccess {
+    fn info(&self) -> Option<ExtensionDescriptor> {
+        None
+    }
+
+    async fn initialize(
+        &self,
+        operator: &Operator,
+        _multipart_part_bytes: NonZeroUsize,
+        initial: AuthorityHead,
+    ) -> Result<(), Error> {
+        if HEAD_RECORD.read(operator).await?.is_some() {
+            self.observe(operator, DEFAULT_AUTHORITY).await?;
+            return Ok(());
+        }
+        HEAD_RECORD.write(operator, &initial, None).await?;
+        Ok(())
+    }
+
+    async fn observe(
+        &self,
+        operator: &Operator,
+        name: &str,
+    ) -> Result<AuthorityObservation, Error> {
+        require_default(name)?;
+        let control = HEAD_RECORD.read(operator).await?.ok_or_else(|| {
+            Error::new(
+                crate::ErrorKind::NotFound,
+                "open Managed volume",
+                "namespace head is missing",
+            )
+        })?;
+        let head = control.value;
+        if head.minimum_retained_cursor.sequence() > head.current_commit.cursor().sequence() {
+            return Err(Error::corrupt(
+                "read Managed authority",
+                "authority position is invalid",
+            ));
+        }
+        Ok(AuthorityObservation {
+            id: AuthorityId::from_bytes([0; 16]),
+            head,
+            revision: control.revision.unwrap_or_default().into_bytes(),
+        })
+    }
+
+    async fn compare_exchange(
+        &self,
+        operator: &Operator,
+        _multipart_part_bytes: NonZeroUsize,
+        name: &str,
+        observed: &AuthorityObservation,
+        next: AuthorityHead,
+    ) -> Result<bool, Error> {
+        require_default(name)?;
+        let revision = std::str::from_utf8(&observed.revision)
+            .map_err(|_| Error::corrupt("publish Managed namespace", "head revision is invalid"))?;
+        let revision = if revision.is_empty() {
+            None
+        } else {
+            Some(revision)
+        };
+        HEAD_RECORD.write(operator, &next, revision).await
+    }
+
+    async fn begin_collection(
+        &self,
+        operator: &Operator,
+        multipart_part_bytes: NonZeroUsize,
+    ) -> Result<(CollectionFence, AuthorityRoots), Error> {
+        let observed = self.observe(operator, DEFAULT_AUTHORITY).await?;
+        let mut rotated = observed.head;
+        rotated.gc_epoch = rotated.gc_epoch.next()?;
+        if !self
+            .compare_exchange(
+                operator,
+                multipart_part_bytes,
+                DEFAULT_AUTHORITY,
+                &observed,
+                rotated,
+            )
+            .await?
+        {
+            return Err(Error::conflict(
+                "collect Managed objects",
+                "namespace authority changed while rotating the GC epoch",
+            ));
+        }
+        let current = self.observe(operator, DEFAULT_AUTHORITY).await?;
+        Ok((
+            CollectionFence {
+                epoch: rotated.gc_epoch,
+                revision: current.revision,
+            },
+            futures::stream::iter([Ok(AuthorityRoot {
+                id: current.id,
+                name: DEFAULT_AUTHORITY.to_owned(),
+                head: current.head,
+            })])
+            .boxed(),
+        ))
+    }
+
+    async fn finish_collection(
+        &self,
+        operator: &Operator,
+        multipart_part_bytes: NonZeroUsize,
+        fence: CollectionFence,
+        roots: &mut AuthorityRoots,
+    ) -> Result<bool, Error> {
+        let root = roots.try_next().await?.ok_or_else(|| {
+            Error::corrupt(
+                "collect Managed objects",
+                "compacted authority root is missing",
+            )
+        })?;
+        if root.name != DEFAULT_AUTHORITY || roots.try_next().await?.is_some() {
+            return Err(Error::corrupt(
+                "collect Managed objects",
+                "compacted authority root set is invalid",
+            ));
+        }
+        let observed = AuthorityObservation {
+            id: root.id,
+            head: root.head,
+            revision: fence.revision,
+        };
+        self.compare_exchange(
+            operator,
+            multipart_part_bytes,
+            DEFAULT_AUTHORITY,
+            &observed,
+            root.head,
+        )
+        .await
+    }
+}
+
+fn require_default(name: &str) -> Result<(), Error> {
+    if name == DEFAULT_AUTHORITY {
+        Ok(())
+    } else {
+        Err(Error::new(
+            crate::ErrorKind::NotFound,
+            "open Managed authority",
+            "the selected authority does not exist",
+        ))
+    }
+}

--- a/crates/core/src/authority/object.rs
+++ b/crates/core/src/authority/object.rs
@@ -63,7 +63,7 @@ impl AuthorityAccess for DefaultAuthorityAccess {
         name: &str,
     ) -> Result<AuthorityObservation, Error> {
         require_default(name)?;
-        let control = HEAD_RECORD.read(operator).await?.ok_or_else(|| {
+        let control = HEAD_RECORD.observe(operator).await?.ok_or_else(|| {
             Error::new(
                 crate::ErrorKind::NotFound,
                 "open Managed volume",

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -28,6 +28,6 @@ pub use error::{Error, ErrorKind, Result};
 pub use ofs_managed_format::v0 as format;
 pub use ofs_managed_format::v0::model as filesystem;
 pub use volume::{
-    AccessFamily, CoreAccess, CreateOptions, ManagedAccess, ManagedObservation, ManagedVolume,
-    VolumeRuntime,
+    AccessFamily, CoreAccess, CreateOptions, GcOutcome, ManagedAccess, ManagedObservation,
+    ManagedVolume, VolumeRuntime,
 };

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,6 +17,7 @@
 
 //! OpenDAL-backed runtime primitives for the Managed v0 format.
 
+pub mod authority;
 pub mod data;
 mod error;
 pub mod storage;

--- a/crates/core/src/volume/gc.rs
+++ b/crates/core/src/volume/gc.rs
@@ -1,0 +1,187 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use futures::{StreamExt as _, TryStreamExt as _};
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+use crate::ErrorKind;
+use crate::authority::{AuthorityAccess, AuthorityHead, AuthorityRoot};
+use crate::format::{GcEpoch, OBJECT_PREFIX, ObjectLocator};
+use crate::work::Spool;
+use crate::work::{JoinItem, OrderedJoin, Unique, WorkContext, sort};
+
+use super::open::{AccessFamily, ManagedVolume};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct GcOutcome {
+    pub scanned: u64,
+    pub deleted: u64,
+    pub deleted_bytes: u64,
+}
+
+impl<A: AccessFamily> ManagedVolume<A> {
+    /// Rotate the upload epoch, compact live metadata, then merge a streamed
+    /// inventory against the streamed reachability set.
+    pub async fn collect(&self) -> Result<GcOutcome, Error> {
+        let authority = self.access().authority();
+        let (fence, mut roots) = authority
+            .begin_collection(self.operator(), self.multipart_part_bytes())
+            .await?;
+        let collection_epoch = fence.epoch;
+
+        let workspace = WorkContext::create(self.work_budget())?;
+        let mut records = workspace.writer("gc-reachable")?;
+        let mut compacted = workspace.writer("gc-authority-roots")?;
+        while let Some(root) = roots.try_next().await? {
+            let collection_commit = self
+                .compact_for_collection(
+                    &workspace,
+                    root.head.current_commit,
+                    collection_epoch,
+                    |reference| records.write(&reference),
+                )
+                .await?;
+            compacted.write(&AuthorityRoot {
+                id: root.id,
+                name: root.name,
+                head: AuthorityHead {
+                    current_commit: collection_commit,
+                    gc_epoch: collection_epoch,
+                    minimum_retained_cursor: collection_commit.cursor(),
+                },
+            })?;
+        }
+        let mut compacted = compacted.finish()?.stream()?.boxed();
+        if !authority
+            .finish_collection(
+                self.operator(),
+                self.multipart_part_bytes(),
+                fence,
+                &mut compacted,
+            )
+            .await?
+        {
+            return Err(Error::new(
+                ErrorKind::Conflict,
+                "collect Managed objects",
+                "namespace authority changed while publishing compacted roots",
+            ));
+        }
+
+        let marks = sort(&workspace, &records.finish()?, |identity| *identity)?;
+        let candidates = self
+            .inventory_candidates(&workspace, collection_epoch)
+            .await?;
+        self.sweep_unreachable(&marks, &candidates).await
+    }
+
+    async fn inventory_candidates(
+        &self,
+        workspace: &WorkContext,
+        current_epoch: GcEpoch,
+    ) -> Result<Spool<ObjectRecord>, Error> {
+        let mut records = workspace.writer("gc-inventory")?;
+        let mut lister = self
+            .operator()
+            .lister_with(OBJECT_PREFIX)
+            .recursive(true)
+            .await
+            .map_err(|error| Error::from_storage("list Managed objects", error))?;
+        while let Some(entry) = lister
+            .try_next()
+            .await
+            .map_err(|error| Error::from_storage("list Managed objects", error))?
+        {
+            if !entry.metadata().is_file() {
+                continue;
+            }
+            let identity = ObjectLocator::parse_key(entry.path()).ok_or_else(|| {
+                Error::corrupt("collect Managed objects", "object key is invalid")
+            })?;
+            if identity.gc_epoch.value() >= current_epoch.value() {
+                continue;
+            }
+            records.write(&ObjectRecord {
+                identity,
+                length: entry.metadata().content_length(),
+            })?;
+        }
+        sort(workspace, &records.finish()?, |record| record.identity)
+    }
+
+    async fn sweep_unreachable(
+        &self,
+        marks: &Spool<ObjectLocator>,
+        candidates: &Spool<ObjectRecord>,
+    ) -> Result<GcOutcome, Error> {
+        let marks = Unique::new(marks.reader()?, |identity: &ObjectLocator| *identity);
+        let candidates = candidates.reader()?;
+        let mut objects = OrderedJoin::new(
+            marks,
+            candidates,
+            |identity| *identity,
+            |record: &ObjectRecord| record.identity,
+        );
+        let mut outcome = GcOutcome::default();
+        let mut deleter = self
+            .operator()
+            .deleter()
+            .await
+            .map_err(|error| Error::from_storage("open Managed object deleter", error))?;
+
+        while let Some(item) = objects.next()? {
+            let candidate = match item {
+                JoinItem::Left(_) => continue,
+                JoinItem::Match(_, _) => {
+                    outcome.scanned = outcome.scanned.checked_add(1).ok_or_else(|| {
+                        Error::corrupt("collect Managed objects", "scanned object count overflows")
+                    })?;
+                    continue;
+                }
+                JoinItem::Right(candidate) => candidate,
+            };
+            outcome.scanned = outcome.scanned.checked_add(1).ok_or_else(|| {
+                Error::corrupt("collect Managed objects", "scanned object count overflows")
+            })?;
+            deleter
+                .delete(candidate.identity.key())
+                .await
+                .map_err(|error| Error::from_storage("delete Managed object", error))?;
+            outcome.deleted = outcome.deleted.checked_add(1).ok_or_else(|| {
+                Error::corrupt("collect Managed objects", "deleted object count overflows")
+            })?;
+            outcome.deleted_bytes = outcome
+                .deleted_bytes
+                .checked_add(candidate.length)
+                .ok_or_else(|| {
+                    Error::corrupt("collect Managed objects", "deleted byte count overflows")
+                })?;
+        }
+        deleter
+            .close()
+            .await
+            .map_err(|error| Error::from_storage("finish Managed object deletion", error))?;
+        Ok(outcome)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+struct ObjectRecord {
+    identity: ObjectLocator,
+    length: u64,
+}

--- a/crates/core/src/volume/mod.rs
+++ b/crates/core/src/volume/mod.rs
@@ -15,19 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! OpenDAL-backed runtime primitives for the Managed v0 format.
+//! Managed volume use cases.
 
-pub mod authority;
-pub mod data;
-mod error;
-pub mod storage;
-pub mod volume;
-pub(crate) mod work;
+mod namespace;
+mod open;
+mod publication;
 
-pub use error::{Error, ErrorKind, Result};
-pub use ofs_managed_format::v0 as format;
-pub use ofs_managed_format::v0::model as filesystem;
-pub use volume::{
+pub use namespace::{Namespace, NamespaceReader};
+pub use open::{
     AccessFamily, CoreAccess, CreateOptions, ManagedAccess, ManagedObservation, ManagedVolume,
     VolumeRuntime,
 };

--- a/crates/core/src/volume/mod.rs
+++ b/crates/core/src/volume/mod.rs
@@ -17,10 +17,12 @@
 
 //! Managed volume use cases.
 
+mod gc;
 mod namespace;
 mod open;
 mod publication;
 
+pub use gc::GcOutcome;
 pub use namespace::{Namespace, NamespaceReader};
 pub use open::{
     AccessFamily, CoreAccess, CreateOptions, ManagedAccess, ManagedObservation, ManagedVolume,

--- a/crates/core/src/volume/namespace.rs
+++ b/crates/core/src/volume/namespace.rs
@@ -1,0 +1,616 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Encoding, merging, and validation of path-ordered namespace streams.
+
+use std::future::Future;
+
+use futures::StreamExt as _;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+use crate::data::validate_file_map;
+use crate::filesystem::{
+    ChangeCursor, NamespaceNode, NamespaceRecord, NamespaceValue, NodeId, VolumeId,
+    validate_portable_path,
+};
+use crate::format::{
+    FileExtentMap, GcEpoch, NamespaceChangeSegment, NamespaceCommit, ObjectClass,
+    RecordStreamSizer, StreamKind, StreamRef,
+};
+use crate::storage::{RecordStreamReader, RecordStreamWriter};
+use crate::work::{
+    AsyncOrderedMerge, AsyncOrderedRead, JoinItem, OrderedJoin, OrderedMerge, OrderedRead,
+    RunCompactor, Spool, SpoolReader, WorkContext,
+};
+
+use super::open::{AccessFamily, ManagedVolume};
+
+/// Ordered namespace projection shared by Managed authority and Sync.
+#[derive(Clone)]
+pub struct Namespace<C> {
+    pub volume_id: VolumeId,
+    pub cursor: ChangeCursor,
+    pub root: NodeId,
+    pub(crate) entries: Spool<NamespaceRecord<C>>,
+}
+
+impl<C: DeserializeOwned> Namespace<C> {
+    pub fn reader(&self) -> Result<NamespaceReader<C>, Error> {
+        Ok(NamespaceReader {
+            inner: self.entries.reader()?,
+            previous_path: None,
+        })
+    }
+}
+
+pub struct NamespaceReader<C> {
+    inner: SpoolReader<NamespaceRecord<C>>,
+    previous_path: Option<String>,
+}
+
+impl<C: DeserializeOwned> NamespaceReader<C> {
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> Result<Option<NamespaceRecord<C>>, Error> {
+        let next = self.inner.next()?;
+        if let Some(record) = &next {
+            validate_portable_path(&record.path)?;
+            if self
+                .previous_path
+                .as_ref()
+                .is_some_and(|previous| previous >= &record.path)
+            {
+                return Err(Error::corrupt(
+                    "read filesystem namespace",
+                    "namespace paths are not strictly ordered",
+                ));
+            }
+            self.previous_path = Some(record.path.clone());
+        }
+        Ok(next)
+    }
+}
+
+impl<C: DeserializeOwned> OrderedRead for NamespaceReader<C> {
+    type Item = NamespaceRecord<C>;
+
+    fn next(&mut self) -> Result<Option<Self::Item>, Error> {
+        NamespaceReader::next(self)
+    }
+}
+
+pub(super) struct PlannedDelta {
+    records: Spool<NamespaceRecord<FileExtentMap>>,
+    pub(super) compaction_weight_bytes: u64,
+}
+
+pub(super) async fn write_genesis<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    root_node_id: NodeId,
+    gc_epoch: GcEpoch,
+) -> Result<StreamRef, Error> {
+    let root = NamespaceRecord::<FileExtentMap> {
+        path: String::new(),
+        value: Some(NamespaceNode {
+            node_id: root_node_id,
+            generation: 1,
+            attributes: Default::default(),
+            value: NamespaceValue::Directory { generation: 1 },
+        }),
+    };
+    let mut writer = RecordStreamWriter::open(
+        volume.operator(),
+        gc_epoch,
+        ObjectClass::NamespaceSegment,
+        StreamKind::NAMESPACE_SNAPSHOT,
+        volume.multipart_part_bytes(),
+    )
+    .await?;
+    writer.write(&root).await?;
+    writer.close().await
+}
+
+pub(super) async fn write_snapshot<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    namespace: &Namespace<FileExtentMap>,
+    gc_epoch: GcEpoch,
+) -> Result<StreamRef, Error> {
+    let mut source = namespace.reader()?;
+    let mut writer = RecordStreamWriter::open(
+        volume.operator(),
+        gc_epoch,
+        ObjectClass::NamespaceSegment,
+        StreamKind::NAMESPACE_SNAPSHOT,
+        volume.multipart_part_bytes(),
+    )
+    .await?;
+    while let Some(record) = source.next()? {
+        writer.write(&record).await?;
+    }
+    writer.close().await
+}
+
+pub(super) fn plan_delta(
+    workspace: &WorkContext,
+    previous: &Namespace<FileExtentMap>,
+    target: &Namespace<FileExtentMap>,
+) -> Result<Option<PlannedDelta>, Error> {
+    let mut records = OrderedJoin::new(
+        previous.reader()?,
+        target.reader()?,
+        |record: &NamespaceRecord<FileExtentMap>| record.path.clone(),
+        |record: &NamespaceRecord<FileExtentMap>| record.path.clone(),
+    );
+    let mut writer = workspace.writer("namespace-delta")?;
+    let mut sizer = RecordStreamSizer::new();
+    let mut changed = false;
+    while let Some(record) = records.next()? {
+        let (path, value) = match record {
+            JoinItem::Left(record) => (record.path, None),
+            JoinItem::Right(record) => (record.path, record.value),
+            JoinItem::Match(old, new) => {
+                if old.value == new.value {
+                    continue;
+                }
+                (new.path, new.value)
+            }
+        };
+        let record = NamespaceRecord { path, value };
+        let encoded_bytes = writer.write_sized(&record)?;
+        sizer.write_encoded(encoded_bytes)?;
+        changed = true;
+    }
+    if !changed {
+        return Ok(None);
+    }
+    Ok(Some(PlannedDelta {
+        records: writer.finish()?,
+        compaction_weight_bytes: sizer.finish()?,
+    }))
+}
+
+pub(super) async fn write_delta<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    delta: PlannedDelta,
+    older: Vec<NamespaceChangeSegment>,
+    compaction_weight_bytes: u64,
+    end_cursor: ChangeCursor,
+    gc_epoch: GcEpoch,
+) -> Result<NamespaceChangeSegment, Error> {
+    for segment in &older {
+        segment
+            .stream
+            .require(StreamKind::NAMESPACE_CHANGES, ObjectClass::NamespaceSegment)?;
+    }
+    let remotes = futures::stream::iter(older.into_iter().enumerate())
+        .map(|(priority, segment)| async move {
+            Ok::<_, Error>((
+                priority,
+                ChangeSource::remote(volume, segment.stream).await?,
+            ))
+        })
+        .buffer_unordered(volume.stream_concurrency());
+    futures::pin_mut!(remotes);
+    let mut remote_sources = Vec::new();
+    while let Some(remote) = remotes.next().await {
+        remote_sources.push(remote?);
+    }
+    remote_sources.sort_by_key(|(priority, _)| *priority);
+    let mut readers = Vec::with_capacity(remote_sources.len() + 1);
+    readers.push(ChangeSource::local(delta.records)?);
+    readers.extend(remote_sources.into_iter().map(|(_, source)| source));
+    let mut records =
+        AsyncOrderedMerge::from_readers(readers, |record: &NamespaceRecord<FileExtentMap>| {
+            Ok(record.path.clone())
+        })
+        .await?;
+    let mut writer = RecordStreamWriter::open(
+        volume.operator(),
+        gc_epoch,
+        ObjectClass::NamespaceSegment,
+        StreamKind::NAMESPACE_CHANGES,
+        volume.multipart_part_bytes(),
+    )
+    .await?;
+    while let Some((_, selected)) = records
+        .reduce_next_group(None, |selected, _, record| {
+            if selected.is_none() {
+                *selected = Some(record);
+            }
+            Ok(())
+        })
+        .await?
+    {
+        writer
+            .write(&selected.expect("ordered group contains one record"))
+            .await?;
+    }
+    Ok(NamespaceChangeSegment {
+        end_cursor,
+        compaction_weight_bytes,
+        stream: writer.close().await?,
+    })
+}
+
+enum ChangeInput {
+    Local(crate::work::SpoolReader<NamespaceRecord<FileExtentMap>>),
+    Remote(Box<RecordStreamReader<NamespaceRecord<FileExtentMap>>>),
+}
+
+struct ChangeSource {
+    input: ChangeInput,
+    previous: Option<String>,
+}
+
+impl ChangeSource {
+    fn local(records: Spool<NamespaceRecord<FileExtentMap>>) -> Result<Self, Error> {
+        Ok(Self {
+            input: ChangeInput::Local(records.reader()?),
+            previous: None,
+        })
+    }
+
+    async fn remote<A: AccessFamily>(
+        volume: &ManagedVolume<A>,
+        reference: StreamRef,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            input: ChangeInput::Remote(Box::new(
+                RecordStreamReader::open(volume.operator(), reference).await?,
+            )),
+            previous: None,
+        })
+    }
+
+    async fn next(&mut self) -> Result<Option<NamespaceRecord<FileExtentMap>>, Error> {
+        let record = match &mut self.input {
+            ChangeInput::Local(reader) => reader.next()?,
+            ChangeInput::Remote(reader) => reader.next().await?,
+        };
+        if let Some(record) = &record {
+            require_increasing_path(&mut self.previous, &record.path)?;
+            self.previous = Some(record.path.clone());
+        }
+        Ok(record)
+    }
+}
+
+impl AsyncOrderedRead for ChangeSource {
+    type Item = NamespaceRecord<FileExtentMap>;
+
+    fn next(&mut self) -> impl Future<Output = Result<Option<Self::Item>, Error>> {
+        ChangeSource::next(self)
+    }
+}
+
+pub(super) async fn read_views<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    workspace: &WorkContext,
+    views: &[(&NamespaceCommit, ChangeCursor)],
+) -> Result<Vec<Namespace<FileExtentMap>>, Error> {
+    let mut groups = Vec::<Vec<usize>>::new();
+    for (index, (commit, cursor)) in views.iter().copied().enumerate() {
+        validate_view(commit, cursor)?;
+        match groups.iter_mut().find(|group| {
+            let snapshot = views[group[0]].0.namespace_snapshot;
+            snapshot.change_cursor == commit.namespace_snapshot.change_cursor
+                && snapshot.stream == commit.namespace_snapshot.stream
+        }) {
+            Some(group) => group.push(index),
+            None => groups.push(vec![index]),
+        }
+    }
+
+    let mut output = (0..views.len()).map(|_| None).collect::<Vec<_>>();
+    for group in groups {
+        let snapshot_ref = views[group[0]].0.namespace_snapshot;
+        snapshot_ref.stream.require(
+            StreamKind::NAMESPACE_SNAPSHOT,
+            ObjectClass::NamespaceSegment,
+        )?;
+        let snapshot = download(
+            volume,
+            workspace,
+            snapshot_ref.stream,
+            snapshot_ref.change_cursor,
+        )
+        .await?;
+        let mut segments = Vec::new();
+        for index in group.iter().copied() {
+            let (commit, cursor) = views[index];
+            if cursor == commit.namespace_snapshot.change_cursor {
+                continue;
+            }
+            for segment in commit.namespace_changes.iter().copied() {
+                if !segments.iter().any(|current: &NamespaceChangeSegment| {
+                    current.end_cursor == segment.end_cursor && current.stream == segment.stream
+                }) {
+                    segments.push(segment);
+                }
+            }
+        }
+        let downloads = futures::stream::iter(segments)
+            .map(|segment| async move {
+                segment
+                    .stream
+                    .require(StreamKind::NAMESPACE_CHANGES, ObjectClass::NamespaceSegment)?;
+                Ok::<_, Error>(DownloadedChange {
+                    end_cursor: segment.end_cursor,
+                    stream: segment.stream,
+                    records: download(volume, workspace, segment.stream, segment.end_cursor)
+                        .await?,
+                })
+            })
+            .buffer_unordered(volume.stream_concurrency());
+        futures::pin_mut!(downloads);
+        let mut changes = Vec::new();
+        while let Some(download) = downloads.next().await {
+            changes.push(download?);
+        }
+        for index in group {
+            let (commit, cursor) = views[index];
+            output[index] = Some(read_from_downloads(
+                volume,
+                commit,
+                cursor,
+                workspace,
+                snapshot.clone(),
+                &changes,
+            )?);
+        }
+    }
+    output
+        .into_iter()
+        .map(|view| view.ok_or_else(|| Error::corrupt("read Managed namespace", "view is missing")))
+        .collect()
+}
+
+fn validate_view(commit: &NamespaceCommit, view_cursor: ChangeCursor) -> Result<(), Error> {
+    if view_cursor == commit.namespace_snapshot.change_cursor {
+        return Ok(());
+    }
+    if view_cursor != commit.change_cursor {
+        return Err(Error::corrupt(
+            "read Managed namespace",
+            "commit cursor does not match the requested view",
+        ));
+    }
+    if commit.namespace_changes.is_empty() {
+        return Err(Error::corrupt(
+            "read Managed namespace",
+            "namespace commit has no change stream for its cursor",
+        ));
+    }
+    if commit.namespace_snapshot.change_cursor > view_cursor {
+        return Err(Error::corrupt(
+            "read Managed namespace",
+            "snapshot is newer than the requested view",
+        ));
+    }
+    for segment in commit.namespace_changes.iter().copied() {
+        if segment.end_cursor > commit.change_cursor || segment.compaction_weight_bytes == 0 {
+            return Err(Error::corrupt(
+                "read Managed namespace",
+                "namespace change descriptor is invalid",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn select_record(
+    selected: &mut Option<VersionedRecord>,
+    candidate: VersionedRecord,
+) -> Result<(), Error> {
+    match selected.as_ref() {
+        Some(current) if current.change_cursor == candidate.change_cursor => {
+            if current.value != candidate.value {
+                return Err(Error::corrupt(
+                    "read Managed namespace",
+                    "one change cursor has conflicting namespace records",
+                ));
+            }
+        }
+        Some(current) if current.change_cursor > candidate.change_cursor => {}
+        _ => *selected = Some(candidate),
+    }
+    Ok(())
+}
+
+fn read_from_downloads<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    commit: &NamespaceCommit,
+    view_cursor: ChangeCursor,
+    workspace: &WorkContext,
+    snapshot: Spool<VersionedRecord>,
+    changes: &[DownloadedChange],
+) -> Result<Namespace<FileExtentMap>, Error> {
+    if view_cursor == commit.namespace_snapshot.change_cursor {
+        return finish_view(volume, commit, view_cursor, workspace, snapshot);
+    }
+    let mut streams = RunCompactor::new(workspace.fan_in());
+    streams.push(snapshot, |group| merge_group(workspace, group, view_cursor))?;
+    for segment in &commit.namespace_changes {
+        let stream = changes
+            .iter()
+            .find(|download| {
+                download.end_cursor == segment.end_cursor && download.stream == segment.stream
+            })
+            .ok_or_else(|| {
+                Error::corrupt(
+                    "read Managed namespace",
+                    "namespace change stream was not downloaded",
+                )
+            })?;
+        streams.push(stream.records.clone(), |group| {
+            merge_group(workspace, group, view_cursor)
+        })?;
+    }
+    let merged = streams
+        .finish(|group| merge_group(workspace, group, view_cursor))?
+        .ok_or_else(|| Error::corrupt("read Managed namespace", "namespace has no streams"))?;
+    finish_view(volume, commit, view_cursor, workspace, merged)
+}
+
+fn finish_view<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    commit: &NamespaceCommit,
+    view_cursor: ChangeCursor,
+    workspace: &WorkContext,
+    merged: Spool<VersionedRecord>,
+) -> Result<Namespace<FileExtentMap>, Error> {
+    let mut output = workspace.writer("namespace")?;
+    let mut records = merged.reader()?;
+    let mut previous_output = None::<String>;
+    let mut root_seen = false;
+    while let Some(record) = records.next()? {
+        let Some(node) = record.value else {
+            continue;
+        };
+        let record = NamespaceRecord {
+            path: record.path,
+            value: Some(node),
+        };
+        validate_record(volume, &record, &mut previous_output, &mut root_seen)?;
+        output.write(&record)?;
+    }
+    if !root_seen {
+        return Err(Error::corrupt(
+            "read Managed namespace",
+            "namespace root is missing",
+        ));
+    }
+    Ok(Namespace {
+        volume_id: commit.volume_id,
+        cursor: view_cursor,
+        root: volume.format().root_node_id(),
+        entries: output.finish()?,
+    })
+}
+
+async fn download<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    workspace: &WorkContext,
+    reference: StreamRef,
+    cursor: ChangeCursor,
+) -> Result<Spool<VersionedRecord>, Error> {
+    let mut remote =
+        RecordStreamReader::<NamespaceRecord<FileExtentMap>>::open(volume.operator(), reference)
+            .await?;
+    let mut local = workspace.writer("namespace-input")?;
+    let mut previous = None::<String>;
+    while let Some(record) = remote.next().await? {
+        require_increasing_path(&mut previous, &record.path)?;
+        previous = Some(record.path.clone());
+        local.write(&VersionedRecord {
+            path: record.path,
+            change_cursor: cursor,
+            value: record.value,
+        })?;
+    }
+    local.finish()
+}
+
+struct DownloadedChange {
+    end_cursor: ChangeCursor,
+    stream: StreamRef,
+    records: Spool<VersionedRecord>,
+}
+
+fn merge_group(
+    workspace: &WorkContext,
+    streams: &[Spool<VersionedRecord>],
+    view_cursor: ChangeCursor,
+) -> Result<Spool<VersionedRecord>, Error> {
+    let readers = streams
+        .iter()
+        .map(Spool::reader)
+        .collect::<Result<Vec<_>, Error>>()?;
+    let mut records =
+        OrderedMerge::from_readers(readers, |record: &VersionedRecord| Ok(record.path.clone()))?;
+    let mut output = workspace.writer("namespace-merge")?;
+
+    while let Some((_, selected)) =
+        records.reduce_next_group(None::<VersionedRecord>, |selected, _, record| {
+            if record.change_cursor <= view_cursor {
+                select_record(selected, record)?;
+            }
+            Ok(())
+        })?
+    {
+        if let Some(record) = selected {
+            output.write(&record)?;
+        }
+    }
+    output.finish()
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct VersionedRecord {
+    path: String,
+    change_cursor: ChangeCursor,
+    value: Option<NamespaceNode<FileExtentMap>>,
+}
+
+fn validate_record<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    record: &NamespaceRecord<FileExtentMap>,
+    previous: &mut Option<String>,
+    root_seen: &mut bool,
+) -> Result<(), Error> {
+    require_increasing_path(previous, &record.path)?;
+    let node = record
+        .value
+        .as_ref()
+        .ok_or_else(|| Error::corrupt("read Managed namespace", "snapshot contains a deletion"))?;
+    validate_portable_path(&record.path)?;
+    if let NamespaceValue::RegularFile { content, data, .. } = &node.value
+        && validate_file_map(data, *content, volume.file_decoding_count()).is_err()
+    {
+        return Err(Error::corrupt(
+            "read Managed namespace",
+            "file content does not match its namespace record",
+        ));
+    }
+    if record.path.is_empty() {
+        if node.node_id != volume.format().root_node_id()
+            || !matches!(node.value, NamespaceValue::Directory { .. })
+        {
+            return Err(Error::corrupt(
+                "read Managed namespace",
+                "namespace root is invalid",
+            ));
+        }
+        *root_seen = true;
+    }
+    *previous = Some(record.path.clone());
+    Ok(())
+}
+
+fn require_increasing_path(previous: &mut Option<String>, path: &str) -> Result<(), Error> {
+    if previous
+        .as_ref()
+        .is_some_and(|previous| previous.as_str() >= path)
+    {
+        return Err(Error::corrupt(
+            "read Managed namespace",
+            "namespace stream is not strictly path ordered",
+        ));
+    }
+    Ok(())
+}

--- a/crates/core/src/volume/open.rs
+++ b/crates/core/src/volume/open.rs
@@ -1,0 +1,497 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Create and open a Managed volume from its experimental v0 format.
+
+use std::num::NonZeroUsize;
+
+use opendal::Operator;
+
+use crate::Error;
+use crate::ErrorKind;
+use crate::authority::{AuthorityAccess, AuthorityObservation, DefaultAuthorityAccess};
+use crate::data::{CoreDataAccess, DataAccess, ExtentCodec, FilePartitioner};
+use crate::filesystem::{ChangeCursor, NodeId, VolumeId};
+use crate::format::{
+    FORMAT_KEY, FORMAT_RECORD, FileDataLayout, FileExtentMap, GcEpoch, NamespaceCommit,
+    NamespaceRevision, VolumeFormat,
+};
+use crate::storage::ControlRecord;
+use crate::work::{WorkBudget, WorkContext};
+
+use super::namespace::{self, Namespace};
+use super::publication;
+
+const FORMAT: ControlRecord<VolumeFormat> = ControlRecord::new(FORMAT_KEY, FORMAT_RECORD);
+
+/// User choices that become a persisted `VolumeFormat`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreateOptions {
+    file_data_layout: FileDataLayout,
+    authority: Option<crate::format::ExtensionDescriptor>,
+}
+
+impl CreateOptions {
+    pub fn new(file_data_layout: FileDataLayout) -> Self {
+        Self {
+            file_data_layout,
+            authority: None,
+        }
+    }
+
+    pub fn with_authority(mut self, authority: crate::format::ExtensionDescriptor) -> Self {
+        self.authority = Some(authority);
+        self
+    }
+
+    pub const fn file_data_layout(&self) -> &FileDataLayout {
+        &self.file_data_layout
+    }
+
+    pub fn authority(&self) -> Option<&crate::format::ExtensionDescriptor> {
+        self.authority.as_ref()
+    }
+}
+
+/// Runtime transfer and work budgets for one opened volume.
+#[derive(Clone, Copy, Debug)]
+pub struct VolumeRuntime {
+    transfer_concurrency: NonZeroUsize,
+    work_memory_bytes: NonZeroUsize,
+    read_gap_bytes: usize,
+    multipart_part_bytes: Option<NonZeroUsize>,
+}
+
+impl VolumeRuntime {
+    pub fn new(
+        transfer_concurrency: NonZeroUsize,
+        work_memory_bytes: NonZeroUsize,
+        read_gap_bytes: usize,
+        multipart_part_bytes: Option<NonZeroUsize>,
+    ) -> Self {
+        Self {
+            transfer_concurrency,
+            work_memory_bytes,
+            read_gap_bytes,
+            multipart_part_bytes,
+        }
+    }
+
+    pub fn standard() -> Self {
+        Self::new(
+            NonZeroUsize::new(4).expect("nonzero"),
+            NonZeroUsize::new(256 * 1024 * 1024).expect("nonzero"),
+            1024 * 1024,
+            None,
+        )
+    }
+}
+
+/// Statically composed data and namespace-authority access.
+pub trait AccessFamily: Clone + Send + Sync + std::fmt::Debug + Unpin + 'static {
+    type Data: DataAccess;
+    type Authority: AuthorityAccess + Clone;
+
+    fn data(&self) -> &Self::Data;
+
+    fn authority(&self) -> &Self::Authority;
+}
+
+/// One Managed access family assembled from independent capabilities.
+#[derive(Clone, Debug, Default)]
+pub struct ManagedAccess<D, A> {
+    data: D,
+    authority: A,
+}
+
+impl<D, A> ManagedAccess<D, A> {
+    pub const fn new(data: D, authority: A) -> Self {
+        Self { data, authority }
+    }
+}
+
+impl<D, A> AccessFamily for ManagedAccess<D, A>
+where
+    D: DataAccess,
+    A: AuthorityAccess + Clone,
+{
+    type Data = D;
+    type Authority = A;
+
+    fn data(&self) -> &Self::Data {
+        &self.data
+    }
+
+    fn authority(&self) -> &Self::Authority {
+        &self.authority
+    }
+}
+
+/// Core whole-file identity access with the `main` authority.
+pub type CoreAccess = ManagedAccess<CoreDataAccess, DefaultAuthorityAccess>;
+
+/// Opened Managed volume facade.
+#[derive(Clone)]
+pub struct ManagedVolume<A: AccessFamily = CoreAccess> {
+    format: VolumeFormat,
+    operator: Operator,
+    multipart_part_bytes: NonZeroUsize,
+    work_budget: WorkBudget,
+    stream_concurrency: usize,
+    read_gap_bytes: usize,
+    access: A,
+    authority_name: String,
+}
+
+pub struct ManagedObservation {
+    pub(crate) namespace: Namespace<FileExtentMap>,
+    pub(crate) authority: AuthorityObservation,
+    pub(crate) commit: NamespaceCommit,
+}
+
+impl ManagedObservation {
+    pub const fn namespace(&self) -> &Namespace<FileExtentMap> {
+        &self.namespace
+    }
+
+    pub const fn authority_id(&self) -> crate::authority::AuthorityId {
+        self.authority.id
+    }
+
+    pub const fn revision(&self) -> NamespaceRevision {
+        self.authority.head.current_commit
+    }
+
+    pub fn can_read_revision(&self, revision: NamespaceRevision) -> bool {
+        let sequence = revision.change_cursor.sequence();
+        let head = self.authority.head;
+        sequence >= head.minimum_retained_cursor.sequence()
+            && sequence <= head.current_commit.change_cursor.sequence()
+    }
+
+    pub const fn gc_epoch(&self) -> GcEpoch {
+        self.authority.head.gc_epoch
+    }
+}
+
+impl<A: AccessFamily> ManagedVolume<A> {
+    pub const fn format(&self) -> &VolumeFormat {
+        &self.format
+    }
+
+    pub const fn id(&self) -> VolumeId {
+        self.format.volume_id()
+    }
+
+    pub fn authority_name(&self) -> &str {
+        &self.authority_name
+    }
+
+    pub const fn operator(&self) -> &Operator {
+        &self.operator
+    }
+
+    pub const fn access(&self) -> &A {
+        &self.access
+    }
+
+    pub const fn work_budget(&self) -> WorkBudget {
+        self.work_budget
+    }
+
+    pub const fn stream_concurrency(&self) -> usize {
+        self.stream_concurrency
+    }
+
+    pub const fn multipart_part_bytes(&self) -> NonZeroUsize {
+        self.multipart_part_bytes
+    }
+
+    pub const fn read_gap_bytes(&self) -> usize {
+        self.read_gap_bytes
+    }
+
+    pub(crate) fn file_decoding_count(&self) -> usize {
+        self.access.data().decoding_count()
+    }
+
+    /// Create a volume in empty storage, or reopen it when the same layout exists.
+    pub async fn create(
+        operator: &Operator,
+        options: CreateOptions,
+        access: A,
+        runtime: VolumeRuntime,
+        authority_name: impl Into<String>,
+    ) -> Result<Self, Error> {
+        require_control_capabilities(operator)?;
+        let format = VolumeFormat::new(
+            VolumeId::generate(),
+            NodeId::generate(),
+            options.file_data_layout,
+            options.authority,
+        );
+        if FORMAT.write(operator, &format, None).await? {
+            let volume =
+                Self::from_parts(format, operator.clone(), access, runtime, authority_name)?;
+            volume.initialize().await?;
+            return Ok(volume);
+        }
+        let existing = Self::open(operator, access, runtime, authority_name).await?;
+        if existing.format.file_data_layout() != format.file_data_layout()
+            || existing.format.authority() != format.authority()
+        {
+            return Err(Error::conflict(
+                "create Managed volume",
+                "storage already contains a different volume layout",
+            ));
+        }
+        Ok(existing)
+    }
+
+    /// Read the volume format from storage and attach runtime access.
+    pub async fn open(
+        operator: &Operator,
+        access: A,
+        runtime: VolumeRuntime,
+        authority_name: impl Into<String>,
+    ) -> Result<Self, Error> {
+        require_control_capabilities(operator)?;
+        let observed = FORMAT.read(operator).await?.ok_or_else(|| {
+            Error::new(
+                ErrorKind::NotFound,
+                "open Managed volume",
+                "volume format is missing",
+            )
+        })?;
+        let volume = Self::from_parts(
+            observed.value,
+            operator.clone(),
+            access,
+            runtime,
+            authority_name,
+        )?;
+        volume.read_authority().await?;
+        Ok(volume)
+    }
+
+    fn from_parts(
+        format: VolumeFormat,
+        operator: Operator,
+        access: A,
+        runtime: VolumeRuntime,
+        authority_name: impl Into<String>,
+    ) -> Result<Self, Error> {
+        let work_budget = WorkBudget::new(runtime.work_memory_bytes, runtime.transfer_concurrency)?;
+        let multipart_part_bytes = runtime.multipart_part_bytes.unwrap_or_else(|| {
+            NonZeroUsize::new(
+                work_budget
+                    .memory_target_bytes()
+                    .saturating_div(runtime.transfer_concurrency.get())
+                    .max(1),
+            )
+            .expect("a positive memory target produces a positive stream window")
+        });
+        validate_access(&format, &access)?;
+        Ok(Self {
+            format,
+            operator,
+            multipart_part_bytes,
+            work_budget,
+            stream_concurrency: runtime.transfer_concurrency.get(),
+            read_gap_bytes: runtime.read_gap_bytes,
+            access,
+            authority_name: authority_name.into(),
+        })
+    }
+
+    async fn initialize(&self) -> Result<(), Error> {
+        let authority = self.access.authority();
+        match authority
+            .observe(&self.operator, &self.authority_name)
+            .await
+        {
+            Ok(_) => return self.observe().await.map(drop),
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+
+        let namespace =
+            namespace::write_genesis(self, self.format.root_node_id(), GcEpoch::ZERO).await?;
+        let commit = NamespaceCommit::genesis(self.id(), namespace);
+        let revision = publication::write_commit(self, GcEpoch::ZERO, &commit).await?;
+        authority
+            .initialize(
+                &self.operator,
+                self.multipart_part_bytes,
+                crate::authority::AuthorityHead {
+                    current_commit: revision,
+                    gc_epoch: GcEpoch::ZERO,
+                    minimum_retained_cursor: ChangeCursor::GENESIS,
+                },
+            )
+            .await
+    }
+
+    pub async fn observe(&self) -> Result<ManagedObservation, Error> {
+        let workspace = WorkContext::create(self.work_budget)?;
+        self.observe_with_base_in(&workspace, None)
+            .await
+            .map(|(observation, _)| observation)
+    }
+
+    pub async fn read_namespace(
+        &self,
+        revision: NamespaceRevision,
+    ) -> Result<Namespace<FileExtentMap>, Error> {
+        let workspace = WorkContext::create(self.work_budget)?;
+        self.read_namespace_in(&workspace, revision).await
+    }
+
+    pub(crate) async fn read_namespace_in(
+        &self,
+        workspace: &WorkContext,
+        revision: NamespaceRevision,
+    ) -> Result<Namespace<FileExtentMap>, Error> {
+        let commit = publication::read_commit(self, revision).await?;
+        namespace::read_views(self, workspace, &[(&commit, revision.change_cursor)])
+            .await?
+            .pop()
+            .ok_or_else(|| Error::corrupt("read Managed namespace", "namespace view is missing"))
+    }
+
+    pub(crate) async fn observe_with_base_in(
+        &self,
+        workspace: &WorkContext,
+        base: Option<NamespaceRevision>,
+    ) -> Result<(ManagedObservation, Option<Namespace<FileExtentMap>>), Error> {
+        let authority = self.read_authority().await?;
+        let head = authority.head;
+        let commit = publication::read_commit(self, head.current_commit).await?;
+        let readable_base = base.filter(|base| {
+            let sequence = base.change_cursor.sequence();
+            sequence >= head.minimum_retained_cursor.sequence()
+                && sequence < head.current_commit.change_cursor.sequence()
+        });
+        let (namespace, base_namespace) = match readable_base {
+            Some(base) => {
+                let reference = if base.change_cursor == head.minimum_retained_cursor
+                    && base.object.locator.gc_epoch < head.current_commit.object.locator.gc_epoch
+                {
+                    head.current_commit
+                } else {
+                    base
+                };
+                let base_commit = publication::read_commit(self, reference).await?;
+                let mut namespaces = namespace::read_views(
+                    self,
+                    workspace,
+                    &[
+                        (&base_commit, base.change_cursor),
+                        (&commit, commit.change_cursor),
+                    ],
+                )
+                .await?
+                .into_iter();
+                let base_namespace = namespaces
+                    .next()
+                    .expect("two requested namespace views include the base");
+                let namespace = namespaces
+                    .next()
+                    .expect("two requested namespace views include the current view");
+                (namespace, Some(base_namespace))
+            }
+            None => {
+                let namespace =
+                    namespace::read_views(self, workspace, &[(&commit, commit.change_cursor)])
+                        .await?
+                        .pop()
+                        .expect("one requested namespace view is returned");
+                (namespace, None)
+            }
+        };
+        Ok((
+            ManagedObservation {
+                namespace,
+                authority,
+                commit,
+            },
+            base_namespace,
+        ))
+    }
+
+    pub(crate) async fn read_authority(&self) -> Result<AuthorityObservation, Error> {
+        self.access
+            .authority()
+            .observe(&self.operator, &self.authority_name)
+            .await
+    }
+
+    pub(crate) async fn replace_head(
+        &self,
+        observed: &AuthorityObservation,
+        head: crate::authority::AuthorityHead,
+    ) -> Result<bool, Error> {
+        self.access
+            .authority()
+            .compare_exchange(
+                &self.operator,
+                self.multipart_part_bytes,
+                &self.authority_name,
+                observed,
+                head,
+            )
+            .await
+    }
+}
+
+fn require_control_capabilities(operator: &Operator) -> Result<(), Error> {
+    let capability = operator.info().full_capability();
+    if capability.read
+        && capability.write
+        && capability.write_with_if_not_exists
+        && capability.write_with_if_match
+    {
+        return Ok(());
+    }
+    Err(Error::new(
+        ErrorKind::Unsupported,
+        "open Managed volume",
+        "storage lacks conditional Managed control operations",
+    ))
+}
+
+fn validate_access(format: &VolumeFormat, access: &impl AccessFamily) -> Result<(), Error> {
+    let layout = format.file_data_layout();
+    if layout.partitioning() != access.data().partitioner().descriptor()
+        || layout.decodings()
+            != access
+                .data()
+                .codec()
+                .descriptor()
+                .into_iter()
+                .cloned()
+                .collect::<Vec<_>>()
+        || format.authority() != access.authority().info().as_ref()
+    {
+        return Err(Error::new(
+            ErrorKind::Unsupported,
+            "open Managed volume",
+            "runtime access does not match the persisted format",
+        ));
+    }
+    Ok(())
+}

--- a/crates/core/src/volume/publication.rs
+++ b/crates/core/src/volume/publication.rs
@@ -1,0 +1,312 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Immutable namespace commits, operation receipts, and atomic publication.
+
+use crate::Error;
+use crate::ErrorKind;
+use crate::authority::AuthorityHead;
+use crate::filesystem::{ChangeCursor, OperationId};
+use crate::format::{
+    COMMIT_RECORD, FileExtentMap, GcEpoch, NamespaceCommit, NamespaceRevision, NamespaceSnapshot,
+    ObjectClass, OperationReceipt, OperationReceiptSegment, RecordStreamSizer,
+};
+use crate::storage::{ImmutableWriter, RecordStreamReader, RecordStreamWriter};
+use crate::work::WorkContext;
+
+use super::namespace::{self, Namespace};
+use super::open::{AccessFamily, ManagedObservation, ManagedVolume};
+
+/// Absorb older compacted segments whose weight is less than twice the newest.
+fn take_merge_tail<T>(
+    segments: &mut Vec<T>,
+    mut compaction_weight_bytes: u64,
+    size: impl Fn(&T) -> u64,
+) -> Result<(Vec<T>, u64), Error> {
+    let mut merged = Vec::new();
+    while segments
+        .last()
+        .is_some_and(|older| size(older) / 2 < compaction_weight_bytes)
+    {
+        let segment = segments.pop().expect("a merge candidate exists");
+        compaction_weight_bytes = compaction_weight_bytes
+            .checked_add(size(&segment))
+            .ok_or_else(|| {
+                Error::corrupt("compact Managed streams", "compaction weight overflows")
+            })?;
+        merged.push(segment);
+    }
+    Ok((merged, compaction_weight_bytes))
+}
+
+impl<A: AccessFamily> ManagedVolume<A> {
+    /// Prepare and atomically publish one successor namespace.
+    pub async fn publish_namespace(
+        &self,
+        observed: &ManagedObservation,
+        target: &Namespace<FileExtentMap>,
+        operation: OperationId,
+    ) -> Result<NamespaceRevision, Error> {
+        let workspace = WorkContext::create(self.work_budget())?;
+        let revision = self
+            .prepare_publication(&workspace, observed, target, operation)
+            .await?;
+        self.commit_publication(observed, revision, operation)
+            .await?;
+        Ok(revision)
+    }
+
+    pub(crate) async fn prepare_publication(
+        &self,
+        workspace: &WorkContext,
+        observed: &ManagedObservation,
+        target: &Namespace<FileExtentMap>,
+        operation: OperationId,
+    ) -> Result<NamespaceRevision, Error> {
+        if target.volume_id != self.id()
+            || target.root != self.format().root_node_id()
+            || target.cursor.sequence() != observed.namespace.cursor.sequence() + 1
+        {
+            return Err(Error::invalid(
+                "publish Managed namespace",
+                "publication ancestry is invalid",
+            ));
+        }
+
+        let mut commit = observed.commit.clone();
+        commit.change_cursor = target.cursor;
+        if observed.namespace.cursor == ChangeCursor::GENESIS {
+            commit.namespace_snapshot = NamespaceSnapshot {
+                change_cursor: target.cursor,
+                stream: namespace::write_snapshot(self, target, observed.gc_epoch()).await?,
+            };
+            commit.namespace_changes.clear();
+        } else if let Some(delta) = namespace::plan_delta(workspace, &observed.namespace, target)? {
+            let (older, compaction_weight_bytes) = take_merge_tail(
+                &mut commit.namespace_changes,
+                delta.compaction_weight_bytes,
+                |segment| segment.compaction_weight_bytes,
+            )?;
+            commit.namespace_changes.push(
+                namespace::write_delta(
+                    self,
+                    delta,
+                    older,
+                    compaction_weight_bytes,
+                    target.cursor,
+                    observed.gc_epoch(),
+                )
+                .await?,
+            );
+        } else {
+            return Err(Error::invalid(
+                "publish Managed namespace",
+                "publication contains no namespace change",
+            ));
+        }
+
+        let operation_record = OperationReceipt {
+            change_cursor: target.cursor,
+            operation_id: operation,
+        };
+        let mut receipt_size = RecordStreamSizer::new();
+        receipt_size.write(&operation_record)?;
+        let (older, compaction_weight_bytes) = take_merge_tail(
+            &mut commit.operation_receipts,
+            receipt_size.finish()?,
+            |segment| segment.compaction_weight_bytes,
+        )?;
+        commit.operation_receipts.push(
+            write_operation_receipts(
+                self,
+                operation_record,
+                older,
+                compaction_weight_bytes,
+                observed.gc_epoch(),
+            )
+            .await?,
+        );
+        write_commit(self, observed.gc_epoch(), &commit).await
+    }
+
+    pub(crate) async fn commit_publication(
+        &self,
+        observed: &ManagedObservation,
+        target: NamespaceRevision,
+        operation: OperationId,
+    ) -> Result<(), Error> {
+        if target.change_cursor.sequence() != observed.namespace.cursor.sequence() + 1 {
+            return Err(Error::invalid(
+                "publish Managed namespace",
+                "prepared publication ancestry is invalid",
+            ));
+        }
+        let current = observed.authority.head;
+        let head = AuthorityHead {
+            current_commit: target,
+            gc_epoch: current.gc_epoch,
+            minimum_retained_cursor: current.minimum_retained_cursor,
+        };
+        if self.replace_head(&observed.authority, head).await? {
+            return Ok(());
+        }
+        let current = self.read_authority().await?;
+        let commit = read_commit(self, current.head.current_commit).await?;
+        if operation_in_commit(self, operation, target.change_cursor, &commit).await? {
+            Ok(())
+        } else {
+            Err(Error::new(
+                ErrorKind::Conflict,
+                "publish Managed namespace",
+                "observed generation changed",
+            ))
+        }
+    }
+
+    pub async fn operation_committed(
+        &self,
+        operation: OperationId,
+        expected_cursor: ChangeCursor,
+        observed: &ManagedObservation,
+    ) -> Result<bool, Error> {
+        operation_in_commit(self, operation, expected_cursor, &observed.commit).await
+    }
+}
+
+async fn write_operation_receipts<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    receipt: OperationReceipt,
+    older: Vec<OperationReceiptSegment>,
+    compaction_weight_bytes: u64,
+    gc_epoch: GcEpoch,
+) -> Result<OperationReceiptSegment, Error> {
+    let mut writer = RecordStreamWriter::open(
+        volume.operator(),
+        gc_epoch,
+        ObjectClass::OperationReceiptSegment,
+        crate::format::StreamKind::OPERATION_RECEIPTS,
+        volume.multipart_part_bytes(),
+    )
+    .await?;
+    writer.write(&receipt).await?;
+    for reference in older.iter().map(|segment| segment.stream) {
+        reference.require(
+            crate::format::StreamKind::OPERATION_RECEIPTS,
+            ObjectClass::OperationReceiptSegment,
+        )?;
+        let mut reader =
+            RecordStreamReader::<OperationReceipt>::open(volume.operator(), reference).await?;
+        while let Some(record) = reader.next().await? {
+            writer.write(&record).await?;
+        }
+    }
+    let first_cursor = older
+        .last()
+        .map_or(receipt.change_cursor, |segment| segment.first_cursor);
+    Ok(OperationReceiptSegment {
+        first_cursor,
+        last_cursor: receipt.change_cursor,
+        compaction_weight_bytes,
+        stream: writer.close().await?,
+    })
+}
+
+pub(super) async fn write_commit<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    gc_epoch: GcEpoch,
+    commit: &NamespaceCommit,
+) -> Result<NamespaceRevision, Error> {
+    let mut writer = ImmutableWriter::open(
+        volume.operator(),
+        gc_epoch,
+        ObjectClass::NamespaceCommit,
+        volume.multipart_part_bytes(),
+    )
+    .await?;
+    writer.write(COMMIT_RECORD.encode(commit)?).await?;
+    let object = writer.close().await?;
+    Ok(NamespaceRevision {
+        object,
+        change_cursor: commit.change_cursor,
+    })
+}
+
+pub(super) async fn read_commit<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    reference: NamespaceRevision,
+) -> Result<NamespaceCommit, Error> {
+    if reference.object.locator.class != ObjectClass::NamespaceCommit {
+        return Err(Error::corrupt(
+            "read Managed namespace",
+            "commit reference has the wrong object class",
+        ));
+    }
+    let bytes = crate::storage::read_immutable(
+        volume.operator(),
+        reference.object,
+        COMMIT_RECORD.maximum_encoded_bytes(),
+    )
+    .await?;
+    let commit: NamespaceCommit = COMMIT_RECORD.decode(&bytes)?;
+    commit.validate(volume.id(), reference.change_cursor)?;
+    Ok(commit)
+}
+
+async fn operation_in_commit<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    operation: OperationId,
+    expected_cursor: ChangeCursor,
+    commit: &NamespaceCommit,
+) -> Result<bool, Error> {
+    Ok(read_operation_receipt(volume, expected_cursor, commit)
+        .await?
+        .is_some_and(|receipt| receipt.operation_id == operation))
+}
+
+async fn read_operation_receipt<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    expected_cursor: ChangeCursor,
+    commit: &NamespaceCommit,
+) -> Result<Option<OperationReceipt>, Error> {
+    let Some(segment) = commit.operation_receipts.iter().find(|segment| {
+        segment.first_cursor <= expected_cursor && expected_cursor <= segment.last_cursor
+    }) else {
+        return Ok(None);
+    };
+    let mut reader =
+        RecordStreamReader::<OperationReceipt>::open(volume.operator(), segment.stream).await?;
+    let mut previous = None;
+    while let Some(record) = reader.next().await? {
+        if previous.is_some_and(|previous| previous <= record.change_cursor)
+            || record.change_cursor < segment.first_cursor
+            || record.change_cursor > segment.last_cursor
+        {
+            return Err(Error::corrupt(
+                "read Managed operation receipt",
+                "operation receipts are not newest first",
+            ));
+        }
+        previous = Some(record.change_cursor);
+        if record.change_cursor == expected_cursor {
+            return Ok(Some(record));
+        }
+    }
+    Err(Error::corrupt(
+        "read Managed operation receipt",
+        "operation receipt segment does not contain its cursor range",
+    ))
+}

--- a/crates/core/src/volume/publication.rs
+++ b/crates/core/src/volume/publication.rs
@@ -17,16 +17,19 @@
 
 //! Immutable namespace commits, operation receipts, and atomic publication.
 
+use serde::{Deserialize, Serialize};
+
 use crate::Error;
 use crate::ErrorKind;
 use crate::authority::AuthorityHead;
-use crate::filesystem::{ChangeCursor, OperationId};
+use crate::data::DataAccess;
+use crate::filesystem::{ChangeCursor, NamespaceRecord, NamespaceValue, OperationId};
 use crate::format::{
     COMMIT_RECORD, FileExtentMap, GcEpoch, NamespaceCommit, NamespaceRevision, NamespaceSnapshot,
     ObjectClass, OperationReceipt, OperationReceiptSegment, RecordStreamSizer,
 };
 use crate::storage::{ImmutableWriter, RecordStreamReader, RecordStreamWriter};
-use crate::work::WorkContext;
+use crate::work::{WorkContext, sort};
 
 use super::namespace::{self, Namespace};
 use super::open::{AccessFamily, ManagedObservation, ManagedVolume};
@@ -185,6 +188,131 @@ impl<A: AccessFamily> ManagedVolume<A> {
     ) -> Result<bool, Error> {
         operation_in_commit(self, operation, expected_cursor, &observed.commit).await
     }
+
+    pub(super) async fn compact_for_collection(
+        &self,
+        workspace: &WorkContext,
+        reference: NamespaceRevision,
+        gc_epoch: GcEpoch,
+        mut visit: impl FnMut(crate::format::ObjectLocator) -> Result<(), Error> + Send,
+    ) -> Result<NamespaceRevision, Error> {
+        let source = read_commit(self, reference).await?;
+        let current = namespace::read_views(self, workspace, &[(&source, source.change_cursor)])
+            .await?
+            .pop()
+            .expect("one requested namespace view is returned");
+        let mut files = workspace.writer("gc-files-by-content")?;
+        let mut compacted = workspace.writer("gc-compacted-namespace")?;
+        let mut records = current.reader()?;
+        while let Some(record) = records.next()? {
+            match record.value.as_ref().map(|node| &node.value) {
+                Some(NamespaceValue::RegularFile { content, .. }) => {
+                    files.write(&ContentFile {
+                        content: *content,
+                        record,
+                    })?;
+                }
+                _ => compacted.write(&record)?,
+            }
+        }
+        let files = sort(workspace, &files.finish()?, |file: &ContentFile| {
+            (file.content, file.record.path.clone())
+        })?;
+        let mut files = files.reader()?;
+        let mut current_content = None;
+        let mut current_data = None;
+        while let Some(mut file) = files.next()? {
+            if current_content != Some(file.content) {
+                let data = file_data(&file.record)?.clone();
+                crate::data::validate_file_map(&data, file.content, self.file_decoding_count())?;
+                let data = crate::data::compact_file_extents(
+                    &data,
+                    self.operator(),
+                    gc_epoch,
+                    self.multipart_part_bytes(),
+                    |mapping| {
+                        self.access().data().validate_extent(&mapping.extent)?;
+                        visit(mapping.extent.stored_range.segment)
+                    },
+                )
+                .await?;
+                mark_file_data_objects(&data, &mut visit)?;
+                current_content = Some(file.content);
+                current_data = Some(data);
+            }
+            *file_data_mut(&mut file.record)? = current_data
+                .clone()
+                .expect("a content group has compacted file data");
+            compacted.write(&file.record)?;
+        }
+        let entries = sort(
+            workspace,
+            &compacted.finish()?,
+            |record: &NamespaceRecord<FileExtentMap>| record.path.clone(),
+        )?;
+        let current = Namespace {
+            volume_id: current.volume_id,
+            cursor: current.cursor,
+            root: current.root,
+            entries,
+        };
+        let namespace_stream = namespace::write_snapshot(self, &current, gc_epoch).await?;
+        visit(namespace_stream.object.locator)?;
+        for receipt in &source.operation_receipts {
+            visit(receipt.stream.object.locator)?;
+        }
+        let commit = NamespaceCommit {
+            volume_id: source.volume_id,
+            change_cursor: source.change_cursor,
+            namespace_snapshot: NamespaceSnapshot {
+                change_cursor: source.change_cursor,
+                stream: namespace_stream,
+            },
+            namespace_changes: Vec::new(),
+            operation_receipts: source.operation_receipts,
+        };
+        let revision = write_commit(self, gc_epoch, &commit).await?;
+        visit(revision.object.locator)?;
+        Ok(revision)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ContentFile {
+    content: crate::filesystem::ContentRef,
+    record: NamespaceRecord<FileExtentMap>,
+}
+
+fn file_data(record: &NamespaceRecord<FileExtentMap>) -> Result<&FileExtentMap, Error> {
+    match record.value.as_ref().map(|node| &node.value) {
+        Some(NamespaceValue::RegularFile { data, .. }) => Ok(data),
+        _ => Err(Error::corrupt(
+            "compact Managed namespace",
+            "content-ordered record is not a regular file",
+        )),
+    }
+}
+
+fn file_data_mut(record: &mut NamespaceRecord<FileExtentMap>) -> Result<&mut FileExtentMap, Error> {
+    match record.value.as_mut().map(|node| &mut node.value) {
+        Some(NamespaceValue::RegularFile { data, .. }) => Ok(data),
+        _ => Err(Error::corrupt(
+            "compact Managed namespace",
+            "content-ordered record is not a regular file",
+        )),
+    }
+}
+
+fn mark_file_data_objects(
+    data: &FileExtentMap,
+    visit: &mut (impl FnMut(crate::format::ObjectLocator) -> Result<(), Error> + Send),
+) -> Result<(), Error> {
+    for run in data.runs() {
+        if let Some(tail) = run.continuation {
+            visit(tail.object.locator)?;
+        }
+    }
+    Ok(())
 }
 
 async fn write_operation_receipts<A: AccessFamily>(

--- a/crates/core/src/work/compact.rs
+++ b/crates/core/src/work/compact.rs
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Resource-bounded compaction of already ordered runs.
+
+use crate::Error;
+
+/// Incrementally compact equivalent ordered inputs without retaining one
+/// descriptor per input.
+pub(crate) struct RunCompactor<T> {
+    fan_in: usize,
+    levels: Vec<Vec<T>>,
+}
+
+impl<T> RunCompactor<T> {
+    pub(crate) fn new(fan_in: usize) -> Self {
+        debug_assert!(fan_in >= 2, "run compaction must make progress");
+        Self {
+            fan_in,
+            levels: Vec::new(),
+        }
+    }
+
+    pub(crate) fn push(
+        &mut self,
+        mut input: T,
+        mut merge: impl FnMut(&[T]) -> Result<T, Error>,
+    ) -> Result<(), Error> {
+        let mut level = 0;
+        loop {
+            if level == self.levels.len() {
+                self.levels.push(Vec::new());
+            }
+            self.levels[level].push(input);
+            if self.levels[level].len() < self.fan_in {
+                return Ok(());
+            }
+            input = merge(&std::mem::take(&mut self.levels[level]))?;
+            level += 1;
+        }
+    }
+
+    pub(crate) fn finish(
+        mut self,
+        mut merge: impl FnMut(&[T]) -> Result<T, Error>,
+    ) -> Result<Option<T>, Error> {
+        let mut inputs = self.levels.drain(..).flatten().collect::<Vec<_>>();
+        while inputs.len() > 1 {
+            let mut output = Vec::with_capacity(inputs.len().div_ceil(self.fan_in));
+            let mut remaining = inputs.into_iter();
+            loop {
+                let group = remaining.by_ref().take(self.fan_in).collect::<Vec<_>>();
+                if group.is_empty() {
+                    break;
+                }
+                if group.len() == 1 {
+                    output.extend(group);
+                } else {
+                    output.push(merge(&group)?);
+                }
+            }
+            inputs = output;
+        }
+        Ok(inputs.pop())
+    }
+}

--- a/crates/core/src/work/mod.rs
+++ b/crates/core/src/work/mod.rs
@@ -19,6 +19,7 @@
 
 mod compact;
 mod ordered;
+mod sort;
 mod spool;
 
 use std::num::NonZeroUsize;
@@ -28,8 +29,9 @@ use crate::Error;
 
 pub(crate) use compact::RunCompactor;
 pub(crate) use ordered::{
-    AsyncOrderedMerge, AsyncOrderedRead, JoinItem, OrderedJoin, OrderedMerge, OrderedRead,
+    AsyncOrderedMerge, AsyncOrderedRead, JoinItem, OrderedJoin, OrderedMerge, OrderedRead, Unique,
 };
+pub(crate) use sort::sort;
 pub(crate) use spool::{Spool, SpoolReader, SpoolWriter};
 
 const MEBIBYTE: usize = 1024 * 1024;
@@ -86,6 +88,10 @@ impl WorkContext {
             })?),
             budget,
         })
+    }
+
+    pub(super) fn sort_run_bytes(&self) -> usize {
+        self.budget.sort_run_bytes
     }
 
     pub fn fan_in(&self) -> usize {

--- a/crates/core/src/work/mod.rs
+++ b/crates/core/src/work/mod.rs
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Bounded local work storage for streaming namespace and data algorithms.
+
+mod compact;
+mod ordered;
+mod spool;
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use crate::Error;
+
+pub(crate) use compact::RunCompactor;
+pub(crate) use ordered::{
+    AsyncOrderedMerge, AsyncOrderedRead, JoinItem, OrderedJoin, OrderedMerge, OrderedRead,
+};
+pub(crate) use spool::{Spool, SpoolReader, SpoolWriter};
+
+const MEBIBYTE: usize = 1024 * 1024;
+
+#[derive(Clone, Copy)]
+pub struct WorkBudget {
+    sort_run_bytes: usize,
+    fan_in: usize,
+}
+
+impl WorkBudget {
+    pub fn new(memory_bytes: NonZeroUsize, concurrency: NonZeroUsize) -> Result<Self, Error> {
+        let fan_in = concurrency.get().checked_add(1).ok_or_else(|| {
+            Error::invalid("configure local work", "stream concurrency overflows")
+        })?;
+        Ok(Self {
+            sort_run_bytes: memory_bytes.get(),
+            fan_in,
+        })
+    }
+
+    pub fn from_mib(memory_mib: NonZeroUsize, concurrency: NonZeroUsize) -> Result<Self, Error> {
+        let memory_bytes = memory_mib
+            .get()
+            .checked_mul(MEBIBYTE)
+            .ok_or_else(|| Error::invalid("configure local work", "work memory overflows"))?;
+        Self::new(
+            NonZeroUsize::new(memory_bytes).expect("positive MiB is a positive byte count"),
+            concurrency,
+        )
+    }
+
+    pub const fn memory_target_bytes(self) -> usize {
+        self.sort_run_bytes
+    }
+}
+
+/// Operation-scoped composition of temporary storage and its resource budget.
+#[derive(Clone)]
+pub struct WorkContext {
+    workspace: Arc<tempfile::TempDir>,
+    budget: WorkBudget,
+}
+
+impl WorkContext {
+    pub fn create(budget: WorkBudget) -> Result<Self, Error> {
+        Self::create_in(budget, &std::env::temp_dir())
+    }
+
+    pub fn create_in(budget: WorkBudget, directory: &std::path::Path) -> Result<Self, Error> {
+        Ok(Self {
+            workspace: Arc::new(tempfile::TempDir::new_in(directory).map_err(|error| {
+                Error::from_io("create Sync workspace", Some(directory), error)
+            })?),
+            budget,
+        })
+    }
+
+    pub fn fan_in(&self) -> usize {
+        self.budget.fan_in
+    }
+
+    pub fn writer<T>(&self, stem: &str) -> Result<SpoolWriter<T>, Error> {
+        SpoolWriter::create(self.workspace.clone(), stem)
+    }
+}

--- a/crates/core/src/work/ordered.rs
+++ b/crates/core/src/work/ordered.rs
@@ -1,0 +1,329 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Constant-memory cursors over ordered record streams.
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::future::Future;
+use std::marker::PhantomData;
+
+use crate::Error;
+
+pub(crate) trait OrderedRead {
+    type Item;
+
+    fn next(&mut self) -> Result<Option<Self::Item>, Error>;
+}
+
+pub(crate) trait AsyncOrderedRead {
+    type Item;
+
+    fn next(&mut self) -> impl Future<Output = Result<Option<Self::Item>, Error>>;
+}
+
+/// The next item from a merge join of two ordered inputs.
+pub(crate) enum JoinItem<L, R> {
+    Left(L),
+    Match(L, R),
+    Right(R),
+}
+
+/// Merge two ordered inputs without retaining either input.
+///
+/// The left input is a lookup set and must have unique keys. A matching left
+/// item is retained while right items with the same key stream past it, so one
+/// stored fact can resolve any number of demands. If either side is exhausted,
+/// the cursor naturally forwards the other side.
+pub(crate) struct OrderedJoin<L, R, FL, FR, K>
+where
+    L: OrderedRead,
+    R: OrderedRead,
+{
+    left: L,
+    right: R,
+    left_key: FL,
+    right_key: FR,
+    left_head: Option<L::Item>,
+    right_head: Option<R::Item>,
+    left_matched: bool,
+    marker: PhantomData<K>,
+}
+
+impl<L, R, FL, FR, K> OrderedJoin<L, R, FL, FR, K>
+where
+    L: OrderedRead,
+    R: OrderedRead,
+    FL: Fn(&L::Item) -> K,
+    FR: Fn(&R::Item) -> K,
+    L::Item: Clone,
+    K: Ord,
+{
+    pub(crate) fn new(left: L, right: R, left_key: FL, right_key: FR) -> Self {
+        Self {
+            left,
+            right,
+            left_key,
+            right_key,
+            left_head: None,
+            right_head: None,
+            left_matched: false,
+            marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn next(&mut self) -> Result<Option<JoinItem<L::Item, R::Item>>, Error> {
+        loop {
+            if self.left_head.is_none() {
+                self.left_head = self.left.next()?;
+                self.left_matched = false;
+            }
+            if self.right_head.is_none() {
+                self.right_head = self.right.next()?;
+            }
+            let ordering = match (&self.left_head, &self.right_head) {
+                (Some(left), Some(right)) => (self.left_key)(left).cmp(&(self.right_key)(right)),
+                (Some(_), None) => Ordering::Less,
+                (None, Some(_)) => Ordering::Greater,
+                (None, None) => return Ok(None),
+            };
+            match ordering {
+                Ordering::Less if self.left_matched => {
+                    self.left_head = None;
+                }
+                Ordering::Less => {
+                    return Ok(Some(JoinItem::Left(
+                        self.left_head.take().expect("left merge item exists"),
+                    )));
+                }
+                Ordering::Equal => {
+                    self.left_matched = true;
+                    return Ok(Some(JoinItem::Match(
+                        self.left_head
+                            .as_ref()
+                            .expect("left merge item exists")
+                            .clone(),
+                        self.right_head.take().expect("right merge item exists"),
+                    )));
+                }
+                Ordering::Greater => {
+                    return Ok(Some(JoinItem::Right(
+                        self.right_head.take().expect("right merge item exists"),
+                    )));
+                }
+            }
+        }
+    }
+}
+
+/// Merge any number of ordered inputs while retaining one item per input.
+pub(crate) struct OrderedMerge<R, T, K, N, F> {
+    readers: Vec<R>,
+    next: N,
+    key: F,
+    pending: OrderedQueue<T, K>,
+}
+
+fn read_next<R: OrderedRead>(reader: &mut R) -> Result<Option<R::Item>, Error> {
+    reader.next()
+}
+
+impl<R, K, F> OrderedMerge<R, R::Item, K, fn(&mut R) -> Result<Option<R::Item>, Error>, F>
+where
+    R: OrderedRead,
+    K: Ord,
+    F: Fn(&R::Item) -> Result<K, Error>,
+{
+    pub(crate) fn from_readers(readers: Vec<R>, key: F) -> Result<Self, Error> {
+        Self::new(readers, read_next::<R>, key)
+    }
+}
+
+impl<R, T, K, N, F> OrderedMerge<R, T, K, N, F>
+where
+    K: Ord,
+    N: FnMut(&mut R) -> Result<Option<T>, Error>,
+    F: Fn(&T) -> Result<K, Error>,
+{
+    pub(crate) fn new(mut readers: Vec<R>, mut next: N, key: F) -> Result<Self, Error> {
+        let mut pending = OrderedQueue::new();
+        for (source, reader) in readers.iter_mut().enumerate() {
+            if let Some(value) = next(reader)? {
+                pending.push(source, key(&value)?, value);
+            }
+        }
+        Ok(Self {
+            readers,
+            next,
+            key,
+            pending,
+        })
+    }
+
+    pub(crate) fn peek_key(&self) -> Option<&K> {
+        self.pending.peek_key()
+    }
+
+    pub(crate) fn next_with_source(&mut self) -> Result<Option<(usize, T)>, Error> {
+        let Some((source, value)) = self.pending.pop() else {
+            return Ok(None);
+        };
+        if let Some(value) = (self.next)(&mut self.readers[source])? {
+            self.pending.push(source, (self.key)(&value)?, value);
+        }
+        Ok(Some((source, value)))
+    }
+
+    /// Consume the next equal-key group into caller-owned reducer state.
+    pub(crate) fn reduce_next_group<S>(
+        &mut self,
+        mut state: S,
+        mut reduce: impl FnMut(&mut S, usize, T) -> Result<(), Error>,
+    ) -> Result<Option<(K, S)>, Error>
+    where
+        K: Eq,
+    {
+        let Some((source, value)) = self.next_with_source()? else {
+            return Ok(None);
+        };
+        let key = (self.key)(&value)?;
+        reduce(&mut state, source, value)?;
+        while self.peek_key() == Some(&key) {
+            let (source, value) = self
+                .next_with_source()?
+                .expect("peeked ordered item remains available");
+            reduce(&mut state, source, value)?;
+        }
+        Ok(Some((key, state)))
+    }
+}
+
+/// Merge asynchronous ordered inputs with the same group semantics as
+/// [`OrderedMerge`].
+pub(crate) struct AsyncOrderedMerge<R, K, F>
+where
+    R: AsyncOrderedRead,
+{
+    readers: Vec<R>,
+    key: F,
+    pending: OrderedQueue<R::Item, K>,
+}
+
+impl<R, K, F> AsyncOrderedMerge<R, K, F>
+where
+    R: AsyncOrderedRead,
+    K: Ord,
+    F: Fn(&R::Item) -> Result<K, Error>,
+{
+    pub(crate) async fn from_readers(mut readers: Vec<R>, key: F) -> Result<Self, Error> {
+        let mut pending = OrderedQueue::new();
+        for (source, reader) in readers.iter_mut().enumerate() {
+            if let Some(value) = reader.next().await? {
+                pending.push(source, key(&value)?, value);
+            }
+        }
+        Ok(Self {
+            readers,
+            key,
+            pending,
+        })
+    }
+
+    async fn next_with_source(&mut self) -> Result<Option<(usize, R::Item)>, Error> {
+        let Some((source, value)) = self.pending.pop() else {
+            return Ok(None);
+        };
+        if let Some(value) = self.readers[source].next().await? {
+            self.pending.push(source, (self.key)(&value)?, value);
+        }
+        Ok(Some((source, value)))
+    }
+
+    pub(crate) async fn reduce_next_group<S>(
+        &mut self,
+        mut state: S,
+        mut reduce: impl FnMut(&mut S, usize, R::Item) -> Result<(), Error>,
+    ) -> Result<Option<(K, S)>, Error>
+    where
+        K: Eq,
+    {
+        let Some((source, value)) = self.next_with_source().await? else {
+            return Ok(None);
+        };
+        let key = (self.key)(&value)?;
+        reduce(&mut state, source, value)?;
+        while self.pending.peek_key() == Some(&key) {
+            let (source, value) = self
+                .next_with_source()
+                .await?
+                .expect("peeked ordered item remains available");
+            reduce(&mut state, source, value)?;
+        }
+        Ok(Some((key, state)))
+    }
+}
+
+/// One source-aware minimum queue shared by synchronous and asynchronous
+/// ordered merges.
+pub(crate) struct OrderedQueue<T, K>(BinaryHeap<OrderedItem<T, K>>);
+
+impl<T, K: Ord> OrderedQueue<T, K> {
+    pub(crate) const fn new() -> Self {
+        Self(BinaryHeap::new())
+    }
+
+    pub(crate) fn push(&mut self, source: usize, key: K, value: T) {
+        self.0.push(OrderedItem { key, value, source });
+    }
+
+    pub(crate) fn peek_key(&self) -> Option<&K> {
+        self.0.peek().map(|item| &item.key)
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<(usize, T)> {
+        self.0.pop().map(|item| (item.source, item.value))
+    }
+}
+
+struct OrderedItem<T, K> {
+    key: K,
+    value: T,
+    source: usize,
+}
+
+impl<T, K: Ord> PartialEq for OrderedItem<T, K> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key && self.source == other.source
+    }
+}
+
+impl<T, K: Ord> Eq for OrderedItem<T, K> {}
+
+impl<T, K: Ord> PartialOrd for OrderedItem<T, K> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T, K: Ord> Ord for OrderedItem<T, K> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .key
+            .cmp(&self.key)
+            .then_with(|| other.source.cmp(&self.source))
+    }
+}

--- a/crates/core/src/work/ordered.rs
+++ b/crates/core/src/work/ordered.rs
@@ -36,6 +36,44 @@ pub(crate) trait AsyncOrderedRead {
     fn next(&mut self) -> impl Future<Output = Result<Option<Self::Item>, Error>>;
 }
 
+/// Remove adjacent duplicate keys from an ordered input.
+pub(crate) struct Unique<R, F, K> {
+    source: R,
+    key: F,
+    previous: Option<K>,
+}
+
+impl<R, F, K> Unique<R, F, K> {
+    pub(crate) const fn new(source: R, key: F) -> Self {
+        Self {
+            source,
+            key,
+            previous: None,
+        }
+    }
+}
+
+impl<R, F, K> OrderedRead for Unique<R, F, K>
+where
+    R: OrderedRead,
+    F: Fn(&R::Item) -> K,
+    K: Eq,
+{
+    type Item = R::Item;
+
+    fn next(&mut self) -> Result<Option<Self::Item>, Error> {
+        while let Some(item) = self.source.next()? {
+            let key = (self.key)(&item);
+            if self.previous.as_ref() == Some(&key) {
+                continue;
+            }
+            self.previous = Some(key);
+            return Ok(Some(item));
+        }
+        Ok(None)
+    }
+}
+
 /// The next item from a merge join of two ordered inputs.
 pub(crate) enum JoinItem<L, R> {
     Left(L),
@@ -176,6 +214,10 @@ where
 
     pub(crate) fn peek_key(&self) -> Option<&K> {
         self.pending.peek_key()
+    }
+
+    pub(crate) fn next(&mut self) -> Result<Option<T>, Error> {
+        Ok(self.next_with_source()?.map(|(_, value)| value))
     }
 
     pub(crate) fn next_with_source(&mut self) -> Result<Option<(usize, T)>, Error> {

--- a/crates/core/src/work/sort.rs
+++ b/crates/core/src/work/sort.rs
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::Error;
+
+use super::compact::RunCompactor;
+use super::ordered::OrderedMerge;
+use super::spool::decode_record;
+use super::{Spool, SpoolReader, WorkContext};
+
+pub(crate) fn sort<T, K>(
+    workspace: &WorkContext,
+    source: &Spool<T>,
+    key: impl Fn(&T) -> K + Copy,
+) -> Result<Spool<T>, Error>
+where
+    T: DeserializeOwned + Serialize,
+    K: Ord,
+{
+    let mut source = source.reader()?;
+    let fan_in = workspace.fan_in();
+    let mut runs = RunCompactor::new(fan_in);
+    loop {
+        let mut records = Vec::new();
+        let mut encoded_bytes = 0_usize;
+        while encoded_bytes < workspace.sort_run_bytes() {
+            let Some(frame_bytes) = source.peek_frame_bytes()? else {
+                break;
+            };
+            if encoded_bytes != 0 && frame_bytes > workspace.sort_run_bytes() - encoded_bytes {
+                break;
+            }
+            let bytes = source
+                .next_frame()?
+                .expect("peeked Sync record remains available");
+            let record = decode_record::<T>(&bytes)?;
+            records.push((key(&record), bytes));
+            encoded_bytes += frame_bytes;
+        }
+        if records.is_empty() {
+            break;
+        }
+        records.sort_by(|left, right| left.0.cmp(&right.0));
+        let mut run = workspace.writer("sort-run")?;
+        for (_, bytes) in records {
+            run.write_frame(&bytes)?;
+        }
+        runs.push(run.finish()?, |group| merge_runs(workspace, group, key))?;
+    }
+    drop(source);
+
+    runs.finish(|runs| merge_runs(workspace, runs, key))?
+        .map_or_else(|| workspace.writer("sorted")?.finish(), Ok)
+}
+
+fn merge_runs<T, K>(
+    workspace: &WorkContext,
+    runs: &[Spool<T>],
+    key: impl Fn(&T) -> K + Copy,
+) -> Result<Spool<T>, Error>
+where
+    T: DeserializeOwned + Serialize,
+    K: Ord,
+{
+    let readers = runs
+        .iter()
+        .map(Spool::reader)
+        .collect::<Result<Vec<_>, Error>>()?;
+    let mut records = OrderedMerge::new(readers, SpoolReader::next_frame, |bytes: &Vec<u8>| {
+        Ok(key(&decode_record::<T>(bytes)?))
+    })?;
+    let mut output = workspace.writer("merge-run")?;
+    while let Some(bytes) = records.next()? {
+        output.write_frame(&bytes)?;
+    }
+    output.finish()
+}

--- a/crates/core/src/work/spool.rs
+++ b/crates/core/src/work/spool.rs
@@ -1,0 +1,228 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter, Read as _, Write as _};
+use std::marker::PhantomData;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::Error;
+use crate::filesystem::OperationId;
+use crate::work::OrderedRead;
+
+struct SpoolFile {
+    _workspace: Arc<tempfile::TempDir>,
+    path: PathBuf,
+}
+
+impl Drop for SpoolFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+pub(crate) struct Spool<T> {
+    file: Arc<SpoolFile>,
+    marker: PhantomData<T>,
+}
+
+impl<T> Clone for Spool<T> {
+    fn clone(&self) -> Self {
+        Self {
+            file: self.file.clone(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T: DeserializeOwned> Spool<T> {
+    pub(crate) fn reader(&self) -> Result<SpoolReader<T>, Error> {
+        SpoolReader::open(self.file.clone())
+    }
+}
+
+pub(crate) struct SpoolWriter<T> {
+    workspace: Option<Arc<tempfile::TempDir>>,
+    path: PathBuf,
+    writer: Option<BufWriter<File>>,
+    marker: PhantomData<T>,
+}
+
+impl<T> SpoolWriter<T> {
+    pub(super) fn create(workspace: Arc<tempfile::TempDir>, stem: &str) -> Result<Self, Error> {
+        let path = workspace
+            .path()
+            .join(format!("{stem}-{}", OperationId::generate()));
+        let file = File::options()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .map_err(|error| Error::from_io("create Sync record stream", Some(&path), error))?;
+        Ok(Self {
+            workspace: Some(workspace),
+            path,
+            writer: Some(BufWriter::new(file)),
+            marker: PhantomData,
+        })
+    }
+}
+
+impl<T> Drop for SpoolWriter<T> {
+    fn drop(&mut self) {
+        drop(self.writer.take());
+        if self.workspace.is_some() {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+impl<T: Serialize> SpoolWriter<T> {
+    pub(crate) fn write(&mut self, value: &T) -> Result<(), Error> {
+        self.write_sized(value).map(drop)
+    }
+
+    pub(crate) fn write_sized(&mut self, value: &T) -> Result<usize, Error> {
+        let mut bytes = Vec::new();
+        ciborium::into_writer(value, &mut bytes)
+            .map_err(|_| Error::invalid("write Sync record stream", "record cannot be encoded"))?;
+        let length = bytes.len();
+        self.write_frame(&bytes)?;
+        Ok(length)
+    }
+
+    pub(super) fn write_frame(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        let length = u32::try_from(bytes.len())
+            .map_err(|_| Error::invalid("write Sync record stream", "record is too large"))?;
+        let writer = self.writer.as_mut().expect("unfinished Sync record writer");
+        writer
+            .write_all(&length.to_le_bytes())
+            .and_then(|()| writer.write_all(bytes))
+            .map_err(|error| Error::from_io("write Sync record stream", Some(&self.path), error))?;
+        Ok(())
+    }
+
+    pub(crate) fn finish(mut self) -> Result<Spool<T>, Error> {
+        let mut writer = self.writer.take().expect("unfinished Sync record writer");
+        writer.flush().map_err(|error| {
+            Error::from_io("finish Sync record stream", Some(&self.path), error)
+        })?;
+        drop(writer);
+        let workspace = self
+            .workspace
+            .take()
+            .expect("unfinished Sync record writer");
+        Ok(Spool {
+            file: Arc::new(SpoolFile {
+                _workspace: workspace,
+                path: self.path.clone(),
+            }),
+            marker: PhantomData,
+        })
+    }
+}
+
+pub(crate) struct SpoolReader<T> {
+    file: Arc<SpoolFile>,
+    reader: BufReader<File>,
+    pending_length: Option<usize>,
+    marker: PhantomData<T>,
+}
+
+impl<T: DeserializeOwned> SpoolReader<T> {
+    fn open(spool: Arc<SpoolFile>) -> Result<Self, Error> {
+        let file = File::open(&spool.path)
+            .map_err(|error| Error::from_io("open Sync record stream", Some(&spool.path), error))?;
+        Ok(Self {
+            file: spool,
+            reader: BufReader::new(file),
+            pending_length: None,
+            marker: PhantomData,
+        })
+    }
+
+    pub(crate) fn next(&mut self) -> Result<Option<T>, Error> {
+        let Some(bytes) = self.next_frame()? else {
+            return Ok(None);
+        };
+        decode_record(&bytes).map(Some)
+    }
+
+    pub(super) fn next_frame(&mut self) -> Result<Option<Vec<u8>>, Error> {
+        let Some(frame_bytes) = self.peek_frame_bytes()? else {
+            return Ok(None);
+        };
+        let length = frame_bytes - size_of::<u32>();
+        self.pending_length = None;
+        let mut bytes = vec![0; length];
+        self.reader.read_exact(&mut bytes).map_err(|error| {
+            Error::from_io("read Sync record stream", Some(&self.file.path), error)
+        })?;
+        Ok(Some(bytes))
+    }
+
+    pub(super) fn peek_frame_bytes(&mut self) -> Result<Option<usize>, Error> {
+        if let Some(length) = self.pending_length {
+            return length
+                .checked_add(size_of::<u32>())
+                .map(Some)
+                .ok_or_else(|| {
+                    Error::corrupt("read Sync record stream", "record length overflows")
+                });
+        }
+        let mut length = [0_u8; size_of::<u32>()];
+        let first = self.reader.read(&mut length[..1]).map_err(|error| {
+            Error::from_io("read Sync record stream", Some(&self.file.path), error)
+        })?;
+        if first == 0 {
+            return Ok(None);
+        }
+        self.reader.read_exact(&mut length[1..]).map_err(|error| {
+            Error::from_io("read Sync record stream", Some(&self.file.path), error)
+        })?;
+        let length = u32::from_le_bytes(length) as usize;
+        self.pending_length = Some(length);
+        length
+            .checked_add(size_of::<u32>())
+            .map(Some)
+            .ok_or_else(|| Error::corrupt("read Sync record stream", "record length overflows"))
+    }
+}
+
+impl<T: DeserializeOwned> OrderedRead for SpoolReader<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Result<Option<Self::Item>, Error> {
+        SpoolReader::next(self)
+    }
+}
+
+pub(super) fn decode_record<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, Error> {
+    let mut input = std::io::Cursor::new(bytes);
+    let value = ciborium::from_reader(&mut input)
+        .map_err(|_| Error::corrupt("read Sync record stream", "record is invalid"))?;
+    if input.position() != bytes.len() as u64 {
+        return Err(Error::corrupt(
+            "read Sync record stream",
+            "record has trailing bytes",
+        ));
+    }
+    Ok(value)
+}

--- a/crates/core/src/work/spool.rs
+++ b/crates/core/src/work/spool.rs
@@ -21,6 +21,7 @@ use std::marker::PhantomData;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use futures::Stream;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
@@ -56,6 +57,15 @@ impl<T> Clone for Spool<T> {
 impl<T: DeserializeOwned> Spool<T> {
     pub(crate) fn reader(&self) -> Result<SpoolReader<T>, Error> {
         SpoolReader::open(self.file.clone())
+    }
+
+    /// Read this bounded spill through asynchronous stream combinators.
+    pub(crate) fn stream(&self) -> Result<impl Stream<Item = Result<T, Error>> + use<T>, Error> {
+        let reader = self.reader()?;
+        Ok(futures::stream::try_unfold(
+            reader,
+            |mut reader| async move { Ok(reader.next()?.map(|record| (record, reader))) },
+        ))
     }
 }
 

--- a/crates/core/tests/authority.rs
+++ b/crates/core/tests/authority.rs
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::num::NonZeroUsize;
+
+use ofs_core::ErrorKind;
+use ofs_core::authority::{AuthorityAccess, DefaultAuthorityAccess};
+use ofs_core::filesystem::{ChangeCursor, Digest};
+use ofs_core::format::{
+    AuthorityHead, GcEpoch, NamespaceRevision, ObjectClass, ObjectId, ObjectLocator, ObjectRef,
+};
+use opendal::Operator;
+use opendal::services::Memory;
+
+fn memory_operator() -> Operator {
+    Operator::new(Memory::default())
+        .expect("memory service configuration is valid")
+        .finish()
+}
+
+fn genesis_head() -> AuthorityHead {
+    AuthorityHead {
+        current_commit: NamespaceRevision {
+            object: ObjectRef {
+                locator: ObjectLocator {
+                    gc_epoch: GcEpoch::ZERO,
+                    class: ObjectClass::NamespaceCommit,
+                    id: ObjectId::from_bytes([1; 16]),
+                },
+                encoded_length: 1,
+                digest: Digest::from_bytes([2; 32]),
+            },
+            change_cursor: ChangeCursor::GENESIS,
+        },
+        gc_epoch: GcEpoch::ZERO,
+        minimum_retained_cursor: ChangeCursor::GENESIS,
+    }
+}
+
+#[tokio::test]
+async fn core_authority_owns_only_main() {
+    let operator = memory_operator();
+    let access = DefaultAuthorityAccess;
+    let expected = genesis_head();
+    access
+        .initialize(&operator, NonZeroUsize::new(1024).unwrap(), expected)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        access.observe(&operator, "main").await.unwrap().head,
+        expected
+    );
+    assert_eq!(
+        access
+            .observe(&operator, "feature")
+            .await
+            .unwrap_err()
+            .kind(),
+        ErrorKind::NotFound
+    );
+}

--- a/crates/core/tests/volume.rs
+++ b/crates/core/tests/volume.rs
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use ofs_core::format::{DEFAULT_DATA_SEGMENT_TARGET_BYTES, FileDataLayout};
+use ofs_core::{CoreAccess, CreateOptions, ErrorKind, ManagedVolume, Result, VolumeRuntime};
+use opendal::Operator;
+use opendal::services::Fs;
+
+fn fs_operator(root: &std::path::Path) -> Operator {
+    Operator::new(Fs::default().root(root.to_string_lossy().as_ref()))
+        .expect("filesystem service configuration is valid")
+        .finish()
+}
+
+#[tokio::test]
+async fn rejects_storage_without_conditional_publication() -> Result<()> {
+    let storage = tempfile::tempdir().unwrap();
+    let operator = fs_operator(storage.path());
+    let options = CreateOptions::new(FileDataLayout::whole_identity(
+        DEFAULT_DATA_SEGMENT_TARGET_BYTES,
+    )?);
+    let error = ManagedVolume::create(
+        &operator,
+        options,
+        CoreAccess::default(),
+        VolumeRuntime::standard(),
+        "main",
+    )
+    .await
+    .err()
+    .expect("filesystem storage has no conditional replace capability");
+    assert_eq!(error.kind(), ErrorKind::Unsupported);
+    Ok(())
+}


### PR DESCRIPTION
This PR adds the managed volume lifecycle.

It defines the authority extension boundary, volume creation and observation, namespace publication, and fenced object collection. The core authority remains responsible for `main`; extensions wrap it and add their own authorities. Replica sync and CLI behavior are out of scope.

Depends on #30. Part of #26.

Parts of this PR were written with AI assistance. I reviewed the code and take responsibility for it.

## Validation

- `cargo x lint`
- `cargo x check`
- `cargo x test`
- `cargo x licenses`
