### PR TITLE
chore: migrate HawkEye to v7

### DIFF
--- a/licenserc.toml
+++ b/licenserc.toml
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-headerPath = "Apache-2.0-ASF.txt"
+[header]
+builtin = "Apache-2.0-ASF"
 
+[files]
 includes = ['**/*.rs', '**/*.yml', '**/*.yaml', '**/*.toml']


### PR DESCRIPTION
# Which issue does this PR close?

N/A — this is a maintenance migration for the license-header tooling.

# Rationale for this change

HawkEye v7 uses a new configuration schema, so the v6 configuration needs to be migrated before the latest release can be used.

# What changes are included in this PR?

- migrate the HawkEye configuration to v7
- keep installation versionless so repository workflows resolve the latest release
- validate 19 selected files with 0 changes, 0 conflicts, and 0 unsupported files
- run `cargo x licenses` successfully

# Are there any user-facing changes?

No.