### PR TITLE
feat: publish managed replica changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,6 +1106,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "unicode-casefold",
+ "unicode-normalization",
  "uuid",
  "walkdir",
 ]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -35,6 +35,8 @@ serde = { version = "1", features = ["derive"] }
 tempfile = "3"
 tokio = { version = "1", features = ["fs", "io-util"] }
 tokio-util.workspace = true
+unicode-casefold = "0.2"
+unicode-normalization = "0.1"
 uuid = { version = "1", features = ["v4"] }
 walkdir = "2.5"
 

--- a/crates/core/src/data/mod.rs
+++ b/crates/core/src/data/mod.rs
@@ -23,6 +23,7 @@ mod file;
 mod lookup;
 mod partition;
 mod range;
+pub(crate) mod reuse;
 mod segment;
 pub(crate) mod write;
 
@@ -33,6 +34,7 @@ pub use file::{ReusableFile, ReusableFileSource, logical_range, restore_file};
 pub use lookup::ContentLookup;
 pub use partition::{FilePartitioner, WholePartitioner};
 pub use range::RangeReader;
+pub use reuse::ContentReuseLookup;
 pub use segment::DataSegmentWriter;
 pub use write::{data_segments, publish_file, publish_file_patch};
 

--- a/crates/core/src/data/reuse.rs
+++ b/crates/core/src/data/reuse.rs
@@ -1,0 +1,363 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Ephemeral, bounded lookup for retained content.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Read as _, Seek as _, SeekFrom, Write as _};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use futures::{StreamExt as _, TryStreamExt as _, future};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use opendal::Operator;
+
+use crate::Error;
+use crate::ErrorKind;
+use crate::filesystem::{ContentRef, NamespaceValue};
+use crate::format::{ExtentRef, ExtentRunRef, FileExtentMap};
+use crate::volume::Namespace;
+use crate::work::{OrderedRead as _, Unique, WorkContext, sort};
+use crate::work::{Spool, SpoolWriter};
+
+use super::{ContentLookup, DataAccess};
+
+const ENTRY_BYTES: u64 = 32 + 8 + 8;
+
+/// Content already reachable from the observed or last-common namespace.
+///
+/// The index belongs to one publication operation and disappears with it. The
+/// fixed-width sorted keys provide constant-memory lookup without creating
+/// durable local state or retaining the namespace in memory.
+#[derive(Clone)]
+pub struct ContentReuseLookup {
+    inner: Arc<KnownContentInner>,
+}
+
+struct KnownContentInner {
+    _workspace: WorkContext,
+    files: Lookup,
+    extents: Lookup,
+}
+
+struct Lookup {
+    files: Mutex<IndexFiles>,
+    entries: u64,
+}
+
+struct IndexFiles {
+    keys: File,
+    values: File,
+    keys_path: PathBuf,
+    values_path: PathBuf,
+}
+
+impl fmt::Debug for ContentReuseLookup {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ContentReuseLookup")
+            .field("files", &self.inner.files.entries)
+            .field("extents", &self.inner.extents.entries)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ContentReuseLookup {
+    pub(crate) fn build(
+        workspace: &WorkContext,
+        files: &Spool<(ContentRef, FileExtentMap)>,
+        extents: &Spool<(ContentRef, ExtentRef)>,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            inner: Arc::new(KnownContentInner {
+                _workspace: workspace.clone(),
+                files: build_lookup(workspace, "known-files", files)?,
+                extents: build_lookup(workspace, "known-extents", extents)?,
+            }),
+        })
+    }
+}
+
+impl ContentLookup for ContentReuseLookup {
+    fn file(&self, content: ContentRef) -> Result<Option<FileExtentMap>, Error> {
+        lookup(&self.inner.files, content)
+    }
+
+    fn extent(&self, content: ContentRef) -> Result<Option<ExtentRef>, Error> {
+        lookup(&self.inner.extents, content)
+    }
+}
+
+pub(crate) async fn build_known_content<A: DataAccess>(
+    access: &A,
+    operator: &Operator,
+    workspace: &WorkContext,
+    stream_concurrency: usize,
+    observed: &Namespace<FileExtentMap>,
+    base: &Namespace<FileExtentMap>,
+    index_extents: bool,
+) -> Result<ContentReuseLookup, Error> {
+    let mut records = workspace.writer("retained-content")?;
+    let mut files = workspace.writer("retained-files")?;
+    let mut runs = workspace.writer("retained-file-extent-runs")?;
+    let namespaces =
+        std::iter::once(observed).chain((base.cursor != observed.cursor).then_some(base));
+    for namespace in namespaces {
+        let mut namespace = namespace.reader()?;
+        while let Some(record) = namespace.next()? {
+            let Some(node) = record.value else {
+                continue;
+            };
+            let NamespaceValue::RegularFile { content, data, .. } = node.value else {
+                continue;
+            };
+            files.write(&(content, data.clone()))?;
+            if !index_extents {
+                continue;
+            }
+            for run in data.runs() {
+                if run.continuation.is_some() {
+                    runs.write(run)?;
+                } else {
+                    let mapping = &run.inline_extent;
+                    access.validate_extent(&mapping.extent)?;
+                    records.write(&(mapping.extent.content(), mapping.extent.clone()))?;
+                }
+            }
+        }
+    }
+    let runs = sort(workspace, &runs.finish()?, |run: &ExtentRunRef| {
+        run.continuation
+            .expect("continued extent run has a stream")
+            .object
+            .locator
+    })?;
+    let mut previous: Option<ExtentRunRef> = None;
+    {
+        let readers = runs
+            .stream()?
+            .map(|run| {
+                run.and_then(|run| {
+                    if let Some(previous) = previous.as_ref().filter(|previous| {
+                        previous.continuation.map(|tail| tail.object.locator)
+                            == run.continuation.map(|tail| tail.object.locator)
+                    }) {
+                        if *previous != run {
+                            return Err(Error::corrupt(
+                                "read Managed retained content",
+                                "one extent segment has conflicting stream references",
+                            ));
+                        }
+                        return Ok(None);
+                    }
+                    previous = Some(run.clone());
+                    Ok(Some(read_extent_run(access, operator, workspace, run)))
+                })
+                .transpose()
+            })
+            .filter_map(future::ready)
+            .try_buffer_unordered(stream_concurrency);
+        futures::pin_mut!(readers);
+        while let Some(extents) = readers.try_next().await? {
+            append_extents(&mut records, &extents)?;
+        }
+    }
+    let records = sort(workspace, &records.finish()?, |(content, extent)| {
+        (
+            *content,
+            extent.stored_range.segment,
+            extent.stored_range.offset,
+        )
+    })?;
+    let files = sort(workspace, &files.finish()?, |(content, _)| *content)?;
+    ContentReuseLookup::build(workspace, &files, &records)
+}
+
+async fn read_extent_run<A: DataAccess>(
+    access: &A,
+    operator: &Operator,
+    workspace: &WorkContext,
+    run: ExtentRunRef,
+) -> Result<Spool<(ContentRef, ExtentRef)>, Error> {
+    let mut output = workspace.writer("retained-file-extents")?;
+    let mut source = super::extent::open_extent_run(&run, operator).await?;
+    while let Some(mapping) = source.next().await? {
+        access.validate_extent(&mapping.extent)?;
+        output.write(&(mapping.extent.content(), mapping.extent))?;
+    }
+    output.finish()
+}
+
+fn append_extents(
+    output: &mut SpoolWriter<(ContentRef, ExtentRef)>,
+    extents: &Spool<(ContentRef, ExtentRef)>,
+) -> Result<(), Error> {
+    let mut extents = extents.reader()?;
+    while let Some(extent) = extents.next()? {
+        output.write(&extent)?;
+    }
+    Ok(())
+}
+
+fn build_lookup<T: Serialize + DeserializeOwned>(
+    workspace: &WorkContext,
+    stem: &str,
+    sorted: &Spool<(ContentRef, T)>,
+) -> Result<Lookup, Error> {
+    let keys_path = workspace.path().join(format!("{stem}.keys"));
+    let values_path = workspace.path().join(format!("{stem}.values"));
+    let mut keys = BufWriter::new(create_file(&keys_path)?);
+    let mut values = BufWriter::new(create_file(&values_path)?);
+    let mut source = Unique::new(sorted.reader()?, |(content, _): &(ContentRef, T)| *content);
+    let mut entries = 0_u64;
+    let mut value_offset = 0_u64;
+    while let Some((content, value)) = source.next()? {
+        let mut encoded = Vec::new();
+        ciborium::into_writer(&value, &mut encoded).map_err(|_| {
+            Error::invalid("build Managed content index", "value cannot be encoded")
+        })?;
+        let encoded_length = u32::try_from(encoded.len()).map_err(|_| {
+            Error::invalid("build Managed content index", "value record is too large")
+        })?;
+        keys.write_all(content.digest().as_bytes())
+            .and_then(|()| keys.write_all(&content.length().to_be_bytes()))
+            .and_then(|()| keys.write_all(&value_offset.to_le_bytes()))
+            .map_err(|error| io_error("write", &keys_path, error))?;
+        values
+            .write_all(&encoded_length.to_le_bytes())
+            .and_then(|()| values.write_all(&encoded))
+            .map_err(|error| io_error("write", &values_path, error))?;
+        value_offset = value_offset
+            .checked_add(4 + encoded.len() as u64)
+            .ok_or_else(|| {
+                Error::invalid("build Managed content index", "index length overflows")
+            })?;
+        entries = entries.checked_add(1).ok_or_else(|| {
+            Error::invalid("build Managed content index", "entry count overflows")
+        })?;
+    }
+    keys.flush()
+        .map_err(|error| io_error("flush", &keys_path, error))?;
+    values
+        .flush()
+        .map_err(|error| io_error("flush", &values_path, error))?;
+    drop(keys);
+    drop(values);
+    Ok(Lookup {
+        files: Mutex::new(IndexFiles {
+            keys: File::open(&keys_path).map_err(|error| io_error("open", &keys_path, error))?,
+            values: File::open(&values_path)
+                .map_err(|error| io_error("open", &values_path, error))?,
+            keys_path,
+            values_path,
+        }),
+        entries,
+    })
+}
+
+fn lookup<T: DeserializeOwned>(lookup: &Lookup, content: ContentRef) -> Result<Option<T>, Error> {
+    let mut files = lookup.files.lock().map_err(|_| {
+        Error::new(
+            ErrorKind::Unavailable,
+            "read Managed content index",
+            "index lock is poisoned",
+        )
+    })?;
+    let mut low = 0_u64;
+    let mut high = lookup.entries;
+    while low < high {
+        let middle = low + (high - low) / 2;
+        let offset = middle
+            .checked_mul(ENTRY_BYTES)
+            .ok_or_else(|| Error::corrupt("read Managed content index", "key offset overflows"))?;
+        files
+            .keys
+            .seek(SeekFrom::Start(offset))
+            .map_err(|error| io_error("read", &files.keys_path, error))?;
+        let mut entry = [0_u8; ENTRY_BYTES as usize];
+        files
+            .keys
+            .read_exact(&mut entry)
+            .map_err(|error| io_error("read", &files.keys_path, error))?;
+        match compare_key(content, &entry) {
+            Ordering::Less => high = middle,
+            Ordering::Greater => low = middle + 1,
+            Ordering::Equal => {
+                let value_offset =
+                    u64::from_le_bytes(entry[40..48].try_into().expect("fixed index entry"));
+                return read_value(&mut files, value_offset).map(Some);
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn create_file(path: &std::path::Path) -> Result<File, Error> {
+    OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| io_error("create", path, error))
+}
+
+fn compare_key(content: ContentRef, entry: &[u8; 48]) -> Ordering {
+    content
+        .digest()
+        .as_bytes()
+        .as_slice()
+        .cmp(&entry[..32])
+        .then_with(|| {
+            content.length().cmp(&u64::from_be_bytes(
+                entry[32..40].try_into().expect("fixed index entry"),
+            ))
+        })
+}
+
+fn read_value<T: DeserializeOwned>(files: &mut IndexFiles, offset: u64) -> Result<T, Error> {
+    files
+        .values
+        .seek(SeekFrom::Start(offset))
+        .map_err(|error| io_error("read", &files.values_path, error))?;
+    let mut length = [0_u8; 4];
+    files
+        .values
+        .read_exact(&mut length)
+        .map_err(|error| io_error("read", &files.values_path, error))?;
+    let mut encoded = vec![0_u8; u32::from_le_bytes(length) as usize];
+    files
+        .values
+        .read_exact(&mut encoded)
+        .map_err(|error| io_error("read", &files.values_path, error))?;
+    let mut input = encoded.as_slice();
+    let value = ciborium::from_reader(&mut input)
+        .map_err(|_| Error::corrupt("read Managed content index", "value record is invalid"))?;
+    if !input.is_empty() {
+        return Err(Error::corrupt(
+            "read Managed content index",
+            "value record has trailing bytes",
+        ));
+    }
+    Ok(value)
+}
+
+fn io_error(action: &'static str, path: &std::path::Path, error: std::io::Error) -> Error {
+    Error::from_io("access Managed content index", Some(path), error).with_context("action", action)
+}

--- a/crates/core/src/sync/engine.rs
+++ b/crates/core/src/sync/engine.rs
@@ -15,16 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use crate::Error;
+use crate::filesystem::ChangeCursor;
 use crate::format::{FileExtentMap, NamespaceRevision};
 use crate::volume::{AccessFamily, CoreAccess, ManagedVolume, Namespace};
 use crate::work::WorkContext;
 
+use super::FileChangeSetEntry;
 use super::ReplicaState;
 use super::install::install;
 use super::replica::state_store::ReplicaStateFile;
+use super::scan::ScannedTree;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SyncOutcome {
@@ -34,7 +38,7 @@ pub struct SyncOutcome {
 }
 
 impl SyncOutcome {
-    fn restored(revision: NamespaceRevision, published: bool) -> Self {
+    pub(super) fn complete(revision: NamespaceRevision, published: bool) -> Self {
         Self {
             conflict_paths: Vec::new(),
             published,
@@ -44,7 +48,7 @@ impl SyncOutcome {
 }
 
 pub struct SyncEngine<A: AccessFamily = CoreAccess> {
-    volume: ManagedVolume<A>,
+    pub(super) volume: ManagedVolume<A>,
 }
 
 impl<A: AccessFamily> SyncEngine<A> {
@@ -52,20 +56,36 @@ impl<A: AccessFamily> SyncEngine<A> {
         Self { volume }
     }
 
-    /// Attach an empty local directory to a Managed volume and materialize its
-    /// current namespace. Interrupted installations resume from durable state.
     pub async fn sync(
         &self,
         root: &Path,
         state_path: &Path,
         resolve_paths: &[String],
     ) -> Result<SyncOutcome, Error> {
-        if !resolve_paths.is_empty() {
-            return Err(Error::unsupported(
-                "restore replica",
-                "conflict resolution requires replica convergence",
-            ));
-        }
+        self.sync_inner(root, state_path, resolve_paths, None).await
+    }
+
+    /// Synchronize immutable staged files using an exhaustive, base-bound set
+    /// of regular-file mutations.
+    pub async fn sync_with_mutations(
+        &self,
+        root: &Path,
+        state_path: &Path,
+        resolve_paths: &[String],
+        mutations: &[FileChangeSetEntry],
+    ) -> Result<SyncOutcome, Error> {
+        self.sync_inner(root, state_path, resolve_paths, Some(mutations))
+            .await
+    }
+
+    async fn sync_inner(
+        &self,
+        root: &Path,
+        state_path: &Path,
+        resolve_paths: &[String],
+        mutations: Option<&[FileChangeSetEntry]>,
+    ) -> Result<SyncOutcome, Error> {
+        validate_inputs(resolve_paths, mutations.unwrap_or_default())?;
         let root = canonical_directory(root)?;
         let workspace_directory = state_path
             .parent()
@@ -80,63 +100,122 @@ impl<A: AccessFamily> SyncEngine<A> {
             .volume
             .observe_with_base_in(&workspace, requested)
             .await?;
-        if let Some(state) = stored.as_ref()
-            && (state.authority_id() != observed.authority_id()
-                || state.authority_name() != self.volume.authority_name())
-        {
-            return Err(Error::invalid(
-                "restore replica",
-                "replica state belongs to a different namespace authority",
-            ));
-        }
+        validate_authority(stored.as_ref(), &observed, &self.volume)?;
 
-        if let Some(mut state) = stored {
-            let Some((target, published)) = state.installation() else {
-                return Err(Error::unsupported(
-                    "synchronize replica",
-                    "an attached replica requires convergence",
-                ));
-            };
+        if let Some((target, published)) = stored.as_ref().and_then(ReplicaState::installation) {
+            let state = stored.expect("checked interrupted installation state");
             let namespace = if observed.revision() == target {
                 &observed.namespace
             } else {
                 loaded.as_ref().unwrap_or(&observed.namespace)
+            };
+            let revision = if observed.revision() == target {
+                target
+            } else {
+                observed.revision()
             };
             return self
                 .install_and_advance(
                     &workspace,
                     &root,
                     &mut state_file,
-                    &mut state,
+                    state,
                     namespace,
-                    if observed.revision() == target {
-                        target
-                    } else {
-                        observed.revision()
-                    },
+                    revision,
+                    None,
                     published,
                 )
                 .await;
         }
 
-        require_empty(&root)?;
-        let mut state = ReplicaState::new(
-            root.clone(),
-            self.volume.id(),
-            observed.authority_id(),
-            self.volume.authority_name().to_owned(),
-            observed.revision(),
-        );
-        self.install_and_advance(
-            &workspace,
-            &root,
-            &mut state_file,
-            &mut state,
-            &observed.namespace,
-            observed.revision(),
-            false,
-        )
-        .await
+        let mut state = match stored {
+            Some(state) => state,
+            None => {
+                let state = ReplicaState::new(
+                    root.clone(),
+                    self.volume.id(),
+                    observed.authority_id(),
+                    self.volume.authority_name().to_owned(),
+                    observed.revision(),
+                );
+                if observed.namespace.cursor == ChangeCursor::GENESIS && !directory_is_empty(&root)?
+                {
+                    state_file.persist(&state)?;
+                    state
+                } else {
+                    require_empty(&root)?;
+                    return self
+                        .install_and_advance(
+                            &workspace,
+                            &root,
+                            &mut state_file,
+                            state,
+                            &observed.namespace,
+                            observed.revision(),
+                            None,
+                            false,
+                        )
+                        .await;
+                }
+            }
+        };
+        if state.has_pending() {
+            return Err(Error::unsupported(
+                "synchronize replica",
+                "pending publication requires recovery",
+            ));
+        }
+        if state.common_revision().cursor().sequence() == observed.revision().cursor().sequence()
+            && state.common_revision() != observed.revision()
+        {
+            return Err(Error::unsupported(
+                "synchronize replica",
+                "equivalent namespace rebasing requires convergence",
+            ));
+        }
+        if !observed.can_read_revision(state.common_revision()) {
+            return Err(Error::unsupported(
+                "synchronize replica",
+                "an expired replica base requires conservative reconciliation",
+            ));
+        }
+
+        let base = loaded.as_ref().unwrap_or(&observed.namespace);
+        let local = self
+            .scan(&workspace, &root, base, &observed, mutations)
+            .await?;
+        let remote_changed = state.common_revision() != observed.revision();
+        match (local, remote_changed) {
+            (ScannedTree::Unchanged, false) => {
+                Ok(SyncOutcome::complete(state.common_revision(), false))
+            }
+            (ScannedTree::Changed(target), false) => {
+                let target = self
+                    .publish_planned_files(&workspace, &root, &observed, &target, mutations)
+                    .await?;
+                let revision = self
+                    .prepare_and_commit(&workspace, &mut state_file, &mut state, &observed, &target)
+                    .await?;
+                Self::advance(&mut state_file, state, revision, true)
+            }
+            (ScannedTree::Unchanged, true) => {
+                self.install_and_advance(
+                    &workspace,
+                    &root,
+                    &mut state_file,
+                    state,
+                    &observed.namespace,
+                    observed.revision(),
+                    Some(base),
+                    false,
+                )
+                .await
+            }
+            (ScannedTree::Changed(_), true) => Err(Error::unsupported(
+                "synchronize replica",
+                "concurrent local and remote changes require reconciliation",
+            )),
+        }
     }
 
     async fn install_and_advance(
@@ -144,18 +223,51 @@ impl<A: AccessFamily> SyncEngine<A> {
         workspace: &WorkContext,
         root: &Path,
         state_file: &mut ReplicaStateFile,
-        state: &mut ReplicaState,
+        mut state: ReplicaState,
         namespace: &Namespace<FileExtentMap>,
         revision: NamespaceRevision,
+        current: Option<&Namespace<FileExtentMap>>,
         published: bool,
     ) -> Result<SyncOutcome, Error> {
         state.begin_install(revision, published);
-        state_file.persist(state)?;
-        install(workspace, root, namespace, &self.volume, None).await?;
-        state.advance(revision);
-        state_file.persist(state)?;
-        Ok(SyncOutcome::restored(revision, published))
+        state_file.persist(&state)?;
+        install(workspace, root, namespace, &self.volume, current).await?;
+        Self::advance(state_file, state, revision, published)
     }
+
+    fn advance(
+        state_file: &mut ReplicaStateFile,
+        mut state: ReplicaState,
+        revision: NamespaceRevision,
+        published: bool,
+    ) -> Result<SyncOutcome, Error> {
+        state.advance(revision);
+        state_file.persist(&state)?;
+        Ok(SyncOutcome::complete(revision, published))
+    }
+}
+
+fn validate_inputs(
+    resolve_paths: &[String],
+    mutations: &[FileChangeSetEntry],
+) -> Result<(), Error> {
+    if !resolve_paths.is_empty() {
+        return Err(Error::unsupported(
+            "synchronize replica",
+            "conflict resolution requires reconciliation",
+        ));
+    }
+    let paths = mutations
+        .iter()
+        .map(|mutation| mutation.path.as_str())
+        .collect::<BTreeSet<_>>();
+    if paths.len() != mutations.len() {
+        return Err(Error::invalid(
+            "synchronize replica",
+            "one file has more than one mutation input",
+        ));
+    }
+    Ok(())
 }
 
 fn canonical_directory(root: &Path) -> Result<PathBuf, Error> {
@@ -163,7 +275,7 @@ fn canonical_directory(root: &Path) -> Result<PathBuf, Error> {
         .map_err(|error| Error::from_io("open replica directory", Some(root), error))?;
     if !root.is_dir() {
         return Err(Error::invalid(
-            "restore replica",
+            "synchronize replica",
             "replica path is not a directory",
         ));
     }
@@ -180,27 +292,48 @@ fn validate_binding<A: AccessFamily>(
     };
     if state.root() != root {
         return Err(Error::invalid(
-            "restore replica",
+            "synchronize replica",
             "replica state belongs to a different local directory",
         ));
     }
     if state.volume_id() != volume.id() {
         return Err(Error::invalid(
-            "restore replica",
+            "synchronize replica",
             "replica state belongs to a different volume",
         ));
     }
     Ok(())
 }
 
-fn require_empty(root: &Path) -> Result<(), Error> {
-    let mut entries = std::fs::read_dir(root)
-        .map_err(|error| Error::from_io("read replica directory", Some(root), error))?;
-    if entries.next().is_some() {
-        return Err(Error::unsupported(
-            "restore replica",
-            "initial publication requires local observation",
+fn validate_authority<A: AccessFamily>(
+    state: Option<&ReplicaState>,
+    observed: &crate::volume::ManagedObservation,
+    volume: &ManagedVolume<A>,
+) -> Result<(), Error> {
+    if let Some(state) = state
+        && (state.authority_id() != observed.authority_id()
+            || state.authority_name() != volume.authority_name())
+    {
+        return Err(Error::invalid(
+            "synchronize replica",
+            "replica state belongs to a different namespace authority",
         ));
     }
     Ok(())
+}
+
+fn require_empty(root: &Path) -> Result<(), Error> {
+    if !directory_is_empty(root)? {
+        return Err(Error::invalid(
+            "synchronize replica",
+            "a replica without state must use an empty local directory",
+        ));
+    }
+    Ok(())
+}
+
+fn directory_is_empty(root: &Path) -> Result<bool, Error> {
+    let mut entries = std::fs::read_dir(root)
+        .map_err(|error| Error::from_io("read replica directory", Some(root), error))?;
+    Ok(entries.next().is_none())
 }

--- a/crates/core/src/sync/mod.rs
+++ b/crates/core/src/sync/mod.rs
@@ -20,7 +20,10 @@
 mod engine;
 mod input;
 mod install;
+mod publish;
+mod rename;
 mod replica;
+mod scan;
 mod segment_install;
 mod state;
 mod transfer;

--- a/crates/core/src/sync/publish.rs
+++ b/crates/core/src/sync/publish.rs
@@ -1,0 +1,800 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Durable file publication followed by atomic namespace publication.
+
+use std::path::{Path, PathBuf};
+
+use crate::Error;
+use crate::data::{ContentHasher, ContentReuseLookup};
+use crate::filesystem::{
+    ContentRef, Digest, NamespaceRecord, NamespaceValue, NodeKind, OperationId,
+};
+use crate::format::{FileExtentMap, NamespaceRevision};
+use crate::volume::AccessFamily;
+use crate::volume::{ManagedObservation, ManagedVolume, Namespace};
+use crate::work::JoinItem;
+use crate::work::{Spool, SpoolWriter, WorkContext};
+use futures::{TryStreamExt as _, stream};
+use serde::{Deserialize, Serialize};
+
+use super::FileChangeSetEntry;
+use super::SyncEngine;
+use super::replica::scan::{LocalEntry, LocalFile, LocalRecord};
+use super::replica::state_store::ReplicaStateFile;
+use super::state::ReplicaState;
+use super::transfer::{FilePublication, publish_file, publish_file_into};
+
+impl<A: AccessFamily> SyncEngine<A> {
+    pub(super) async fn prepare_and_commit(
+        &self,
+        workspace: &WorkContext,
+        state_file: &mut ReplicaStateFile,
+        state: &mut ReplicaState,
+        observed: &ManagedObservation,
+        target: &Namespace<FileExtentMap>,
+    ) -> Result<NamespaceRevision, Error> {
+        let operation = OperationId::generate();
+        let revision = self
+            .volume
+            .prepare_publication(workspace, observed, target, operation)
+            .await?;
+        state.begin_publication(
+            observed.revision(),
+            revision,
+            operation,
+            observed.gc_epoch(),
+        )?;
+        state_file.persist(state)?;
+        self.volume
+            .commit_publication(observed, revision, operation)
+            .await?;
+        Ok(revision)
+    }
+
+    /// Observe local files without writing remote objects.
+    ///
+    /// Unchanged base files keep their maps. Changed files keep only a content
+    /// identity; [`Self::publish_planned_files`] uploads them after planning.
+    pub(super) async fn observe_local_files(
+        &self,
+        workspace: &WorkContext,
+        root: &Path,
+        base: &Namespace<FileExtentMap>,
+        entries: Spool<LocalEntry>,
+        mutations: Option<&[FileChangeSetEntry]>,
+    ) -> Result<Spool<LocalRecord>, Error> {
+        let trusted_mutations = mutations.is_some();
+        let base_has_files = namespace_has_files(base)?;
+        let mut completed = workspace.writer("observed-local-files")?;
+        let mut pending = workspace.writer("observed-local-files-pending")?;
+        let mut mutation_records = workspace.writer("trusted-file-mutations")?;
+        for mutation in mutations.unwrap_or_default() {
+            mutation_records.write(mutation)?;
+        }
+        let mutation_records = crate::work::sort(
+            workspace,
+            &mutation_records.finish()?,
+            |mutation: &FileChangeSetEntry| mutation.path.clone(),
+        )?;
+        let mut entries = entries.reader()?;
+        let mut base_records = base.reader()?;
+        let mut mutation_records = mutation_records.reader()?;
+        let mut base_head = base_records.next()?;
+        let mut mutation_head = mutation_records.next()?;
+        while let Some(entry) = entries.next()? {
+            while base_head
+                .as_ref()
+                .is_some_and(|record| record.path < entry.path)
+            {
+                base_head = base_records.next()?;
+            }
+            if mutation_head
+                .as_ref()
+                .is_some_and(|mutation| mutation.path < entry.path)
+            {
+                return Err(Error::invalid(
+                    "observe local files",
+                    "trusted mutation path is absent from the local directory",
+                ));
+            }
+            if entry.kind != NodeKind::RegularFile {
+                if mutation_head
+                    .as_ref()
+                    .is_some_and(|mutation| mutation.path == entry.path)
+                {
+                    return Err(Error::invalid(
+                        "observe local files",
+                        "trusted mutation path is not a regular file",
+                    ));
+                }
+                completed.write(&LocalRecord {
+                    path: entry.path,
+                    kind: entry.kind,
+                    executable: entry.executable,
+                    file: None,
+                })?;
+                continue;
+            }
+            let previous = base_head
+                .as_ref()
+                .filter(|record| record.path == entry.path)
+                .and_then(|record| record.value.as_ref())
+                .and_then(|node| node.file())
+                .map(|(_, content, data)| LocalFile {
+                    content,
+                    data: data.clone(),
+                });
+            let mutation = if mutation_head
+                .as_ref()
+                .is_some_and(|mutation| mutation.path == entry.path)
+            {
+                let mutation = mutation_head.take().expect("matching mutation exists");
+                mutation_head = mutation_records.next()?;
+                let previous = previous.as_ref().ok_or_else(|| {
+                    Error::invalid(
+                        "observe local files",
+                        "trusted mutation has no base regular file",
+                    )
+                })?;
+                if previous.content != mutation.base {
+                    return Err(Error::invalid(
+                        "observe local files",
+                        "trusted mutation does not match the base file content",
+                    ));
+                }
+                Some(mutation)
+            } else {
+                None
+            };
+            let length = entry.length.expect("a scanned regular file has a length");
+            if trusted_mutations
+                && mutation.is_none()
+                && let Some(previous) = previous
+            {
+                if length != previous.content.length() {
+                    return Err(Error::invalid(
+                        "observe local files",
+                        "trusted mutations omit a file whose length changed",
+                    ));
+                }
+                completed.write(&LocalRecord {
+                    path: entry.path,
+                    kind: entry.kind,
+                    executable: entry.executable,
+                    file: Some(previous),
+                })?;
+                continue;
+            }
+            // ContentRef is a function of the publish stream. Hash locally only
+            // when identity is the decision: same-path no-op detection, or a
+            // new path that may be a rename of a known base file.
+            let identity_decides_publication = mutation.is_none()
+                && (previous
+                    .as_ref()
+                    .is_some_and(|previous| previous.content.length() == length)
+                    || (previous.is_none() && (trusted_mutations || base_has_files)));
+            if identity_decides_publication {
+                pending.write(&PendingObserve {
+                    path: entry.path,
+                    executable: entry.executable,
+                    length,
+                    previous,
+                })?;
+                continue;
+            }
+            completed.write(&LocalRecord {
+                path: entry.path,
+                kind: entry.kind,
+                executable: entry.executable,
+                file: Some(unpublished_file(length)),
+            })?;
+        }
+        if mutation_head.is_some() {
+            return Err(Error::invalid(
+                "observe local files",
+                "trusted mutation path is absent from the local directory",
+            ));
+        }
+        let hashed = hash_pending_files(
+            workspace,
+            root,
+            pending.finish()?,
+            self.volume.stream_concurrency(),
+        )
+        .await?;
+        crate::work::merge_sorted(
+            workspace,
+            vec![completed.finish()?, hashed],
+            |record: &LocalRecord| record.path.clone(),
+        )
+    }
+
+    /// Upload only files selected by the plan that still lack durable maps.
+    pub(super) async fn publish_planned_files(
+        &self,
+        workspace: &WorkContext,
+        root: &Path,
+        observed: &ManagedObservation,
+        target: &Namespace<FileExtentMap>,
+        mutations: Option<&[FileChangeSetEntry]>,
+    ) -> Result<Namespace<FileExtentMap>, Error> {
+        let mut unpublished = workspace.writer("planned-unpublished-files")?;
+        let mut records = target.reader()?;
+        let mut needed = false;
+        while let Some(record) = records.next()? {
+            if let Some(node) = &record.value
+                && let Some((.., content, data)) = node.file()
+                && needs_remote_publication(content, data)
+            {
+                needed = true;
+                unpublished.write(&LocalEntry {
+                    path: record.path,
+                    kind: NodeKind::RegularFile,
+                    executable: node.attributes.executable,
+                    length: Some(content.length()),
+                })?;
+            }
+        }
+        if !needed {
+            return Ok(target.clone());
+        }
+        let published = self
+            .publish_local_files(
+                workspace,
+                root,
+                observed,
+                &observed.namespace,
+                unpublished.finish()?,
+                mutations,
+            )
+            .await?;
+        splice_published_maps(workspace, target, &published)
+    }
+
+    pub(super) async fn publish_local_files(
+        &self,
+        workspace: &WorkContext,
+        root: &Path,
+        observed: &ManagedObservation,
+        base: &Namespace<FileExtentMap>,
+        entries: Spool<LocalEntry>,
+        mutations: Option<&[FileChangeSetEntry]>,
+    ) -> Result<Spool<LocalRecord>, Error> {
+        let trusted_mutations = mutations.is_some();
+        let mut completed = workspace.writer("published-local-files")?;
+        let shared_segment_target = self.volume.data_segment_target_bytes();
+        let concurrency = self.volume.stream_concurrency();
+        let mut standalone_lanes = Vec::new();
+        let mut standalone_lane = 0_usize;
+        let mut placement_groups = Vec::new();
+        let mut placement_group = None;
+        let mut placement_group_bytes = 0_u64;
+        let mut placement_group_stored_bound = Some(0_u64);
+        let mut mutation_records = workspace.writer("trusted-file-mutations")?;
+        for mutation in mutations.unwrap_or_default() {
+            mutation_records.write(mutation)?;
+        }
+        let mutation_records = crate::work::sort(
+            workspace,
+            &mutation_records.finish()?,
+            |mutation: &FileChangeSetEntry| mutation.path.clone(),
+        )?;
+        let mut entries = entries.reader()?;
+        let mut base_records = base.reader()?;
+        let mut mutation_records = mutation_records.reader()?;
+        let mut base_head = base_records.next()?;
+        let mut mutation_head = mutation_records.next()?;
+        while let Some(entry) = entries.next()? {
+            while base_head
+                .as_ref()
+                .is_some_and(|record| record.path < entry.path)
+            {
+                base_head = base_records.next()?;
+            }
+            if mutation_head
+                .as_ref()
+                .is_some_and(|mutation| mutation.path < entry.path)
+            {
+                return Err(Error::invalid(
+                    "publish Managed files",
+                    "trusted mutation path is absent from the local directory",
+                ));
+            }
+            if entry.kind != NodeKind::RegularFile {
+                if mutation_head
+                    .as_ref()
+                    .is_some_and(|mutation| mutation.path == entry.path)
+                {
+                    return Err(Error::invalid(
+                        "publish Managed files",
+                        "trusted mutation path is not a regular file",
+                    ));
+                }
+                completed.write(&LocalRecord {
+                    path: entry.path,
+                    kind: entry.kind,
+                    executable: entry.executable,
+                    file: None,
+                })?;
+                continue;
+            }
+            let previous = base_head
+                .as_ref()
+                .filter(|record| record.path == entry.path)
+                .and_then(|record| record.value.as_ref())
+                .and_then(|node| node.file())
+                .map(|(_, content, data)| LocalFile {
+                    content,
+                    data: data.clone(),
+                });
+            let mutation = if mutation_head
+                .as_ref()
+                .is_some_and(|mutation| mutation.path == entry.path)
+            {
+                let mutation = mutation_head.take().expect("matching mutation exists");
+                mutation_head = mutation_records.next()?;
+                let previous = previous.as_ref().ok_or_else(|| {
+                    Error::invalid(
+                        "publish Managed files",
+                        "trusted mutation has no base regular file",
+                    )
+                })?;
+                if previous.content != mutation.base {
+                    return Err(Error::invalid(
+                        "publish Managed files",
+                        "trusted mutation does not match the base file content",
+                    ));
+                }
+                Some(mutation)
+            } else {
+                None
+            };
+            if trusted_mutations
+                && mutation.is_none()
+                && let Some(previous) = previous
+            {
+                if entry.length != Some(previous.content.length()) {
+                    return Err(Error::invalid(
+                        "publish Managed files",
+                        "trusted mutations omit a file whose length changed",
+                    ));
+                }
+                completed.write(&LocalRecord {
+                    path: entry.path,
+                    kind: entry.kind,
+                    executable: entry.executable,
+                    file: Some(previous),
+                })?;
+                continue;
+            }
+            let length = entry.length.expect("a scanned regular file has a length");
+            let pending = PendingFile {
+                path: entry.path,
+                executable: entry.executable,
+                length,
+                publication: match (previous, mutation) {
+                    (Some(previous), Some(mutation))
+                        if supports_patch(&mutation, mutation.base.length(), length) =>
+                    {
+                        FilePublication::Changed {
+                            previous: Box::new(previous),
+                            ranges: mutation.ranges,
+                        }
+                    }
+                    _ => FilePublication::Complete,
+                },
+            };
+            if length != 0 && length <= shared_segment_target {
+                if placement_group.is_none() {
+                    placement_group = Some(workspace.writer("shared-segment-publication-group")?);
+                }
+                placement_group
+                    .as_mut()
+                    .expect("shared placement group is open")
+                    .write(&pending)?;
+                placement_group_stored_bound = placement_group_stored_bound
+                    .zip(self.volume.stored_size_bound(length))
+                    .and_then(|(group, extent)| group.checked_add(extent));
+                placement_group_bytes =
+                    placement_group_bytes.checked_add(length).ok_or_else(|| {
+                        Error::invalid("publish Managed files", "placement byte count overflows")
+                    })?;
+                if placement_group_bytes >= shared_segment_target {
+                    placement_groups.push((
+                        placement_group
+                            .take()
+                            .expect("shared placement group is open")
+                            .finish()?,
+                        placement_group_stored_bound,
+                    ));
+                    placement_group_bytes = 0;
+                    placement_group_stored_bound = Some(0);
+                }
+            } else {
+                if standalone_lanes.len() < concurrency {
+                    standalone_lanes.push(workspace.writer("standalone-publication-lane")?);
+                }
+                standalone_lanes[standalone_lane].write(&pending)?;
+                standalone_lane = (standalone_lane + 1) % concurrency;
+            }
+        }
+        if mutation_head.is_some() {
+            return Err(Error::invalid(
+                "publish Managed files",
+                "trusted mutation path is absent from the local directory",
+            ));
+        }
+        if standalone_lanes.is_empty() && placement_group.is_none() && placement_groups.is_empty() {
+            return completed.finish();
+        }
+        if let Some(group) = placement_group {
+            placement_groups.push((group.finish()?, placement_group_stored_bound));
+        }
+
+        let known = self.volume.known_content(workspace, observed, base).await?;
+        let standalone_lanes = standalone_lanes
+            .into_iter()
+            .map(SpoolWriter::finish)
+            .collect::<Result<Vec<_>, _>>()?;
+        let gc_epoch = observed.gc_epoch();
+        let groups = standalone_lanes
+            .into_iter()
+            .map(|files| PublicationGroup {
+                files,
+                placement: PlacementPlan::Isolated,
+            })
+            .chain(
+                placement_groups
+                    .into_iter()
+                    .map(|(files, stored_payload_bound)| PublicationGroup {
+                        files,
+                        placement: PlacementPlan::Shared(stored_payload_bound),
+                    }),
+            );
+        let publications = stream::iter(groups.map(Ok)).map_ok({
+            let volume = self.volume.clone();
+            let workspace = workspace.clone();
+            let root = root.to_owned();
+            let known = known.clone();
+            move |group| {
+                publish_group_task(
+                    volume.clone(),
+                    workspace.clone(),
+                    root.clone(),
+                    group,
+                    known.clone(),
+                    gc_epoch,
+                )
+            }
+        });
+        let publications = publications.try_buffer_unordered(self.volume.stream_concurrency());
+        futures::pin_mut!(publications);
+        let mut ordered = vec![completed.finish()?];
+        while let Some(publication) = publications.try_next().await? {
+            ordered.push(publication);
+        }
+        crate::work::merge_sorted(workspace, ordered, |record: &LocalRecord| {
+            record.path.clone()
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct PendingFile {
+    path: String,
+    executable: bool,
+    length: u64,
+    publication: FilePublication,
+}
+
+fn supports_patch(mutation: &FileChangeSetEntry, old_length: u64, new_length: u64) -> bool {
+    if new_length < old_length || mutation.ranges.is_empty() {
+        return false;
+    }
+    if mutation
+        .ranges
+        .iter()
+        .any(|range| range.end().ok().is_none_or(|end| end > new_length))
+    {
+        return false;
+    }
+    if new_length == old_length {
+        return true;
+    }
+    let mut covered = old_length;
+    for range in &mutation.ranges {
+        let Ok(end) = range.end() else {
+            return false;
+        };
+        if end <= old_length {
+            continue;
+        }
+        if range.offset > covered {
+            return false;
+        }
+        covered = covered.max(end);
+    }
+    covered == new_length
+}
+
+struct PublicationGroup {
+    files: Spool<PendingFile>,
+    placement: PlacementPlan,
+}
+
+enum PlacementPlan {
+    Isolated,
+    Shared(Option<u64>),
+}
+
+async fn publish_group_task<A: AccessFamily>(
+    volume: ManagedVolume<A>,
+    workspace: WorkContext,
+    root: PathBuf,
+    group: PublicationGroup,
+    known: ContentReuseLookup,
+    gc_epoch: crate::format::GcEpoch,
+) -> Result<Spool<LocalRecord>, Error> {
+    let mut placement = match group.placement {
+        PlacementPlan::Isolated => None,
+        PlacementPlan::Shared(stored_bound) => {
+            Some(volume.data_placement(gc_epoch, u64::MAX, stored_bound))
+        }
+    };
+    let result = async {
+        let mut output = workspace.writer("file-publication-results")?;
+        let mut files = group.files.reader()?;
+        let mut retains_segment = false;
+        while let Some(file) = files.next()? {
+            let path = root.join(&file.path);
+            let length = file.length;
+            let (content, data) = match placement.as_mut() {
+                Some(placement) => {
+                    let (content, data, reused) = publish_file_into(
+                        &volume,
+                        placement,
+                        &path,
+                        &file.publication,
+                        length,
+                        &known,
+                    )
+                    .await?;
+                    retains_segment |= !reused && content.length() != 0;
+                    (content, data)
+                }
+                None => {
+                    publish_file(&volume, &path, &file.publication, length, &known, gc_epoch)
+                        .await?
+                }
+            };
+            output.write(&LocalRecord {
+                path: file.path,
+                kind: NodeKind::RegularFile,
+                executable: file.executable,
+                file: Some(LocalFile { content, data }),
+            })?;
+        }
+        if let Some(mut placement) = placement.take() {
+            if retains_segment {
+                placement.finish().await?;
+            } else {
+                placement.abort().await;
+            }
+        }
+        output.finish()
+    }
+    .await;
+    match result {
+        Ok(files) => Ok(files),
+        Err(error) => {
+            if let Some(mut placement) = placement {
+                placement.abort().await;
+            }
+            Err(error)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct PendingObserve {
+    path: String,
+    executable: bool,
+    length: u64,
+    previous: Option<LocalFile>,
+}
+
+async fn hash_pending_files(
+    workspace: &WorkContext,
+    root: &Path,
+    pending: Spool<PendingObserve>,
+    concurrency: usize,
+) -> Result<Spool<LocalRecord>, Error> {
+    let concurrency = concurrency.max(1);
+    let mut lanes = Vec::new();
+    let mut lane = 0_usize;
+    let mut records = pending.reader()?;
+    while let Some(item) = records.next()? {
+        if lanes.len() < concurrency {
+            lanes.push(workspace.writer("observe-hash-lane")?);
+        }
+        lanes[lane].write(&item)?;
+        lane = (lane + 1) % lanes.len();
+    }
+    if lanes.is_empty() {
+        return workspace.writer("observe-hash-empty")?.finish();
+    }
+    let lanes = lanes
+        .into_iter()
+        .map(SpoolWriter::finish)
+        .collect::<Result<Vec<_>, _>>()?;
+    let hashed = stream::iter(lanes.into_iter().map(Ok)).map_ok({
+        let root = root.to_owned();
+        let workspace = workspace.clone();
+        move |lane| hash_observe_lane(workspace.clone(), root.clone(), lane)
+    });
+    let hashed = hashed.try_buffer_unordered(concurrency);
+    futures::pin_mut!(hashed);
+    let mut finished = Vec::new();
+    while let Some(spool) = hashed.try_next().await? {
+        finished.push(spool);
+    }
+    crate::work::merge_sorted(workspace, finished, |record: &LocalRecord| {
+        record.path.clone()
+    })
+}
+
+async fn hash_observe_lane(
+    workspace: WorkContext,
+    root: PathBuf,
+    pending: Spool<PendingObserve>,
+) -> Result<Spool<LocalRecord>, Error> {
+    let mut output = workspace.writer("observe-hash-results")?;
+    let mut records = pending.reader()?;
+    while let Some(item) = records.next()? {
+        let path = local_path(&root, &item.path);
+        let content = hash_local_file(&path).await?;
+        if item.length != content.length() {
+            return Err(Error::conflict(
+                "observe local files",
+                "local file changed while it was being observed",
+            ));
+        }
+        let file = match item.previous.filter(|previous| previous.content == content) {
+            Some(previous) => previous,
+            None => LocalFile {
+                content,
+                data: FileExtentMap::empty(),
+            },
+        };
+        output.write(&LocalRecord {
+            path: item.path,
+            kind: NodeKind::RegularFile,
+            executable: item.executable,
+            file: Some(file),
+        })?;
+    }
+    output.finish()
+}
+
+fn needs_remote_publication(content: ContentRef, data: &FileExtentMap) -> bool {
+    content.length() > 0 && data.base_run.is_none() && data.patch_levels.is_empty()
+}
+
+fn unpublished_file(length: u64) -> LocalFile {
+    LocalFile {
+        content: unpublished_content(length),
+        data: FileExtentMap::empty(),
+    }
+}
+
+fn unpublished_content(length: u64) -> ContentRef {
+    if length == 0 {
+        return ContentRef::new(Digest::from_bytes(*blake3::hash(&[]).as_bytes()), 0);
+    }
+    // Distinct from any hashed payload so rename matching cannot bind an
+    // unpublished path to a known base file.
+    ContentRef::new(Digest::from_bytes([0; 32]), length)
+}
+
+fn namespace_has_files(namespace: &Namespace<FileExtentMap>) -> Result<bool, Error> {
+    let mut records = namespace.reader()?;
+    while let Some(record) = records.next()? {
+        if record
+            .value
+            .as_ref()
+            .is_some_and(|node| node.file().is_some())
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn local_path(root: &Path, relative: &str) -> PathBuf {
+    if relative.is_empty() {
+        return root.to_path_buf();
+    }
+    root.join(relative.replace('/', std::path::MAIN_SEPARATOR_STR))
+}
+
+async fn hash_local_file(path: &Path) -> Result<ContentRef, Error> {
+    use tokio::io::AsyncReadExt as _;
+
+    let mut file = tokio::fs::File::open(path)
+        .await
+        .map_err(|error| Error::from_io("observe local file", Some(path), error))?;
+    let mut hasher = ContentHasher::default();
+    let mut buffer = vec![0_u8; 256 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .await
+            .map_err(|error| Error::from_io("observe local file", Some(path), error))?;
+        hasher.observe(&buffer[..read]);
+        if read == 0 {
+            break;
+        }
+    }
+    hasher
+        .complete_content()
+        .ok_or_else(|| Error::corrupt("observe local file", "local file hash did not reach EOF"))
+}
+
+fn splice_published_maps(
+    workspace: &WorkContext,
+    target: &Namespace<FileExtentMap>,
+    published: &Spool<LocalRecord>,
+) -> Result<Namespace<FileExtentMap>, Error> {
+    let mut joined = crate::work::OrderedJoin::new(
+        target.reader()?,
+        published.reader()?,
+        |record: &NamespaceRecord<FileExtentMap>| record.path.clone(),
+        |record: &LocalRecord| record.path.clone(),
+    );
+    let mut output = workspace.writer("planned-published-namespace")?;
+    while let Some(item) = joined.next()? {
+        match item {
+            JoinItem::Left(record) => output.write(&record)?,
+            JoinItem::Right(local) => {
+                return Err(Error::corrupt(
+                    "publish planned files",
+                    format!(
+                        "published path {} is absent from the planned namespace",
+                        local.path
+                    ),
+                ));
+            }
+            JoinItem::Match(mut record, local) => {
+                if let Some(node) = record.value.as_mut()
+                    && let Some(file) = local.file
+                    && let NamespaceValue::RegularFile { content, data, .. } = &mut node.value
+                {
+                    *content = file.content;
+                    *data = file.data;
+                }
+                output.write(&record)?;
+            }
+        }
+    }
+    Ok(Namespace {
+        volume_id: target.volume_id,
+        cursor: target.cursor,
+        root: target.root,
+        entries: output.finish()?,
+    })
+}

--- a/crates/core/src/sync/rename.rs
+++ b/crates/core/src/sync/rename.rs
@@ -1,0 +1,269 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Correlate unique file fingerprints without materializing the namespace.
+
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+use crate::filesystem::{
+    ContentRef, FileVersionId, NamespaceNode, NamespaceRecord, NamespaceValue, NodeAttributes,
+    NodeId,
+};
+use crate::format::FileExtentMap;
+use crate::work::OrderedMerge;
+
+use super::replica::scan::LocalRecord;
+use super::scan::next_generation;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+enum RenameCandidate {
+    Local {
+        path: String,
+        executable: bool,
+        fingerprint: ContentRef,
+        data: FileExtentMap,
+    },
+    Base {
+        path: String,
+        fingerprint: ContentRef,
+        node: NamespaceNode<FileExtentMap>,
+    },
+}
+
+impl RenameCandidate {
+    const fn fingerprint(&self) -> ContentRef {
+        match self {
+            Self::Local { fingerprint, .. } | Self::Base { fingerprint, .. } => *fingerprint,
+        }
+    }
+
+    fn path(&self) -> &str {
+        match self {
+            Self::Local { path, .. } | Self::Base { path, .. } => path,
+        }
+    }
+}
+
+pub(super) struct RenameCandidates {
+    records: crate::work::SpoolWriter<RenameCandidate>,
+}
+
+impl RenameCandidates {
+    pub(super) fn new(workspace: &crate::work::WorkContext) -> Result<Self, Error> {
+        Ok(Self {
+            records: workspace.writer("rename-candidates")?,
+        })
+    }
+
+    pub(super) fn local(&mut self, local: LocalRecord) -> Result<(), Error> {
+        self.records.write(&RenameCandidate::Local {
+            path: local.path,
+            executable: local.executable,
+            fingerprint: local
+                .file
+                .as_ref()
+                .expect("a local regular file has published content")
+                .content,
+            data: local
+                .file
+                .expect("a local regular file has published content")
+                .data,
+        })
+    }
+
+    pub(super) fn removed_record(
+        &mut self,
+        record: NamespaceRecord<FileExtentMap>,
+    ) -> Result<(), Error> {
+        let node = record
+            .value
+            .ok_or_else(|| Error::corrupt("scan replica", "base namespace contains a deletion"))?;
+        self.removed_node(record.path, node)
+    }
+
+    pub(super) fn removed_node(
+        &mut self,
+        path: String,
+        node: NamespaceNode<FileExtentMap>,
+    ) -> Result<(), Error> {
+        let Some((_, fingerprint, _)) = node.file() else {
+            return Ok(());
+        };
+        self.records.write(&RenameCandidate::Base {
+            path,
+            fingerprint,
+            node,
+        })
+    }
+
+    pub(super) fn resolve(
+        self,
+        workspace: &crate::work::WorkContext,
+    ) -> Result<crate::work::Spool<NamespaceRecord<FileExtentMap>>, Error> {
+        let candidates = crate::work::sort(
+            workspace,
+            &self.records.finish()?,
+            |candidate: &RenameCandidate| (candidate.fingerprint(), candidate.path().to_owned()),
+        )?;
+        let mut output = workspace.writer("resolved-renames")?;
+        let mut groups = OrderedMerge::from_readers(
+            vec![candidates.reader()?],
+            |candidate: &RenameCandidate| Ok(candidate.fingerprint()),
+        )?;
+        while let Some((_, group)) = groups
+            .reduce_next_group(CandidateGroup::default(), |group, _, candidate| {
+                group.push(candidate, &mut output)
+            })?
+        {
+            group.finish(&mut output)?;
+        }
+        crate::work::sort(
+            workspace,
+            &output.finish()?,
+            |record: &NamespaceRecord<FileExtentMap>| record.path.clone(),
+        )
+    }
+}
+
+#[derive(Default)]
+struct CandidateGroup {
+    local: Option<RenameCandidate>,
+    base: Option<RenameCandidate>,
+    ambiguous_local: bool,
+    ambiguous_base: bool,
+}
+
+impl CandidateGroup {
+    fn push(
+        &mut self,
+        candidate: RenameCandidate,
+        output: &mut crate::work::SpoolWriter<NamespaceRecord<FileExtentMap>>,
+    ) -> Result<(), Error> {
+        match candidate {
+            RenameCandidate::Local { .. } if self.ambiguous_local => {
+                write_new_file(output, candidate)
+            }
+            RenameCandidate::Local { .. } => match self.local.replace(candidate) {
+                Some(previous) => {
+                    self.ambiguous_local = true;
+                    write_new_file(output, previous)?;
+                    write_new_file(
+                        output,
+                        self.local
+                            .take()
+                            .expect("second local candidate was stored"),
+                    )
+                }
+                None => Ok(()),
+            },
+            RenameCandidate::Base { .. } if self.ambiguous_base => Ok(()),
+            RenameCandidate::Base { .. } => {
+                if self.base.replace(candidate).is_some() {
+                    self.base = None;
+                    self.ambiguous_base = true;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn finish(
+        self,
+        output: &mut crate::work::SpoolWriter<NamespaceRecord<FileExtentMap>>,
+    ) -> Result<(), Error> {
+        match (self.local, self.base) {
+            (Some(local), Some(base)) => write_renamed_file(output, local, base),
+            (Some(local), None) => write_new_file(output, local),
+            (None, _) => Ok(()),
+        }
+    }
+}
+
+fn write_new_file(
+    output: &mut crate::work::SpoolWriter<NamespaceRecord<FileExtentMap>>,
+    local: RenameCandidate,
+) -> Result<(), Error> {
+    let RenameCandidate::Local {
+        path,
+        executable,
+        fingerprint,
+        data,
+    } = local
+    else {
+        unreachable!("new files are local rename candidates")
+    };
+    output.write(&NamespaceRecord {
+        path,
+        value: Some(NamespaceNode {
+            node_id: NodeId::generate(),
+            generation: 1,
+            attributes: NodeAttributes { executable },
+            value: NamespaceValue::RegularFile {
+                version: FileVersionId::generate(),
+                content: fingerprint,
+                data,
+            },
+        }),
+    })
+}
+
+fn write_renamed_file(
+    output: &mut crate::work::SpoolWriter<NamespaceRecord<FileExtentMap>>,
+    local: RenameCandidate,
+    base: RenameCandidate,
+) -> Result<(), Error> {
+    let RenameCandidate::Local {
+        path, executable, ..
+    } = local
+    else {
+        unreachable!("a renamed file has one local candidate")
+    };
+    let RenameCandidate::Base { node, .. } = base else {
+        unreachable!("a renamed file has one base candidate")
+    };
+    let NamespaceValue::RegularFile {
+        version,
+        content,
+        data,
+    } = node.value
+    else {
+        return Err(Error::corrupt(
+            "scan replica",
+            "rename candidate is not a regular file",
+        ));
+    };
+    let attributes = NodeAttributes { executable };
+    let generation = if attributes == node.attributes {
+        node.generation
+    } else {
+        next_generation(node.generation)?
+    };
+    output.write(&NamespaceRecord {
+        path,
+        value: Some(NamespaceNode {
+            node_id: node.node_id,
+            generation,
+            attributes,
+            value: NamespaceValue::RegularFile {
+                version,
+                content,
+                data,
+            },
+        }),
+    })
+}

--- a/crates/core/src/sync/replica/fs.rs
+++ b/crates/core/src/sync/replica/fs.rs
@@ -79,6 +79,12 @@ pub(crate) fn entries(root: &Path) -> impl Iterator<Item = Result<walkdir::DirEn
         .map(|entry| entry.map_err(|error| walk_error("walk replica directory", error)))
 }
 
+pub(crate) fn entry_metadata(entry: &walkdir::DirEntry) -> Result<std::fs::Metadata, Error> {
+    entry
+        .metadata()
+        .map_err(|error| walk_error("inspect local path", error))
+}
+
 fn walk_error(operation: &'static str, error: walkdir::Error) -> Error {
     let path = error.path().map(Path::to_path_buf);
     let source = error

--- a/crates/core/src/sync/replica/mod.rs
+++ b/crates/core/src/sync/replica/mod.rs
@@ -16,4 +16,5 @@
 // under the License.
 
 pub(crate) mod fs;
+pub(crate) mod scan;
 pub(super) mod state_store;

--- a/crates/core/src/sync/replica/scan.rs
+++ b/crates/core/src/sync/replica/scan.rs
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Read native filesystem facts into a path-ordered record stream.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use unicode_casefold::UnicodeCaseFold as _;
+use unicode_normalization::UnicodeNormalization as _;
+
+use crate::Error;
+use crate::filesystem::{ContentRef, NodeKind, validate_portable_path};
+use crate::format::FileExtentMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct LocalEntry {
+    pub(crate) path: String,
+    pub(crate) kind: NodeKind,
+    pub(crate) executable: bool,
+    pub(crate) length: Option<u64>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct LocalFile {
+    pub(crate) content: ContentRef,
+    pub(crate) data: FileExtentMap,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct LocalRecord {
+    pub(crate) path: String,
+    pub(crate) kind: NodeKind,
+    pub(crate) executable: bool,
+    pub(crate) file: Option<LocalFile>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct PortableName {
+    parent: String,
+    folded: String,
+}
+
+pub(crate) fn scan(
+    workspace: &crate::work::WorkContext,
+    root: &Path,
+) -> Result<crate::work::Spool<LocalEntry>, Error> {
+    let metadata = std::fs::symlink_metadata(root)
+        .map_err(|error| Error::from_io("inspect local path", Some(root), error))?;
+    if !metadata.is_dir() {
+        return Err(Error::invalid(
+            "scan replica",
+            "local replica root is not a directory",
+        ));
+    }
+
+    let mut records = workspace.writer("local-paths")?;
+    records.write(&LocalEntry {
+        path: String::new(),
+        kind: NodeKind::Directory,
+        executable: false,
+        length: None,
+    })?;
+    let mut portable_names = workspace.writer("portable-names")?;
+    for child in crate::sync::replica::fs::entries(root) {
+        let child = child?;
+        let name = child.file_name().to_str().ok_or_else(|| {
+            Error::invalid(
+                "synchronize replica",
+                "local directory contains a non-Unicode name",
+            )
+        })?;
+        let child_path = child.path();
+        let relative = child_path
+            .strip_prefix(root)
+            .expect("walked replica path is below its root");
+        let path = relative
+            .to_str()
+            .ok_or_else(|| {
+                Error::invalid(
+                    "synchronize replica",
+                    "local directory contains a non-Unicode path",
+                )
+            })?
+            .replace(std::path::MAIN_SEPARATOR, "/");
+        validate_portable_path(&path)?;
+        let parent = path.rsplit_once('/').map_or("", |(parent, _)| parent);
+        portable_names.write(&PortableName {
+            parent: parent.to_owned(),
+            folded: name.case_fold().nfc().collect(),
+        })?;
+
+        let metadata = crate::sync::replica::fs::entry_metadata(&child)?;
+        let (kind, executable) = local_entry(&metadata)?;
+        let record = LocalEntry {
+            path: path.clone(),
+            kind,
+            executable,
+            length: (kind == NodeKind::RegularFile).then_some(metadata.len()),
+        };
+        records.write(&record)?;
+    }
+    validate_portable_names(workspace, portable_names.finish()?)?;
+    let records = records.finish()?;
+    crate::work::sort(workspace, &records, |record: &LocalEntry| {
+        record.path.clone()
+    })
+}
+
+fn validate_portable_names(
+    workspace: &crate::work::WorkContext,
+    names: crate::work::Spool<PortableName>,
+) -> Result<(), Error> {
+    let names = crate::work::sort(workspace, &names, |name: &PortableName| {
+        (name.parent.clone(), name.folded.clone())
+    })?;
+    let mut reader = names.reader()?;
+    let mut previous = None;
+    while let Some(name) = reader.next()? {
+        let key = (name.parent, name.folded);
+        if previous.as_ref() == Some(&key) {
+            return Err(Error::invalid(
+                "synchronize replica",
+                "directory contains a case-folding collision",
+            ));
+        }
+        previous = Some(key);
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn local_entry(metadata: &std::fs::Metadata) -> Result<(NodeKind, bool), Error> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    if metadata.is_dir() {
+        return Ok((NodeKind::Directory, false));
+    }
+    if metadata.is_file() {
+        if metadata.nlink() > 1 {
+            return Err(Error::unsupported(
+                "scan replica",
+                "local replica contains a hard-linked file, which Managed Sync does not support",
+            ));
+        }
+        return Ok((
+            NodeKind::RegularFile,
+            metadata.permissions().mode() & 0o111 != 0,
+        ));
+    }
+    Err(Error::unsupported(
+        "scan replica",
+        "local replica contains a symbolic link or special file",
+    ))
+}
+
+#[cfg(not(unix))]
+fn local_entry(metadata: &std::fs::Metadata) -> Result<(NodeKind, bool), Error> {
+    if metadata.is_dir() {
+        Ok((NodeKind::Directory, false))
+    } else if metadata.is_file() {
+        Ok((NodeKind::RegularFile, false))
+    } else {
+        Err(Error::unsupported(
+            "scan replica",
+            "local replica contains a symbolic link or special file",
+        ))
+    }
+}

--- a/crates/core/src/sync/scan.rs
+++ b/crates/core/src/sync/scan.rs
@@ -1,0 +1,322 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Merge a path-ordered local scan with the last common namespace.
+
+use std::path::Path;
+
+use crate::Error;
+use crate::filesystem::{
+    ChangeCursor, FileVersionId, NamespaceNode, NamespaceRecord, NamespaceValue, NodeAttributes,
+    NodeId, NodeKind,
+};
+use crate::format::FileExtentMap;
+use crate::volume::AccessFamily;
+use crate::volume::{ManagedObservation, Namespace};
+use crate::work::{JoinItem, OrderedJoin};
+
+use super::FileChangeSetEntry;
+use super::SyncEngine;
+use super::rename::RenameCandidates;
+use super::replica::scan::LocalRecord;
+
+pub(crate) enum ScannedTree {
+    Unchanged,
+    Changed(Namespace<FileExtentMap>),
+}
+
+impl<A: AccessFamily> SyncEngine<A> {
+    pub(crate) async fn scan(
+        &self,
+        workspace: &crate::work::WorkContext,
+        root: &Path,
+        base: &Namespace<FileExtentMap>,
+        _observed: &ManagedObservation,
+        mutations: Option<&[FileChangeSetEntry]>,
+    ) -> Result<ScannedTree, Error> {
+        let entries = crate::sync::replica::scan::scan(workspace, root)?;
+        let local = self
+            .observe_local_files(workspace, root, base, entries, mutations)
+            .await?;
+        let next_cursor = base
+            .cursor
+            .sequence()
+            .checked_add(1)
+            .map(ChangeCursor::from_sequence);
+        let mut output = workspace.writer("scanned-namespace")?;
+        let mut renames = RenameCandidates::new(workspace)?;
+        let mut changed_directories = workspace.writer("changed-directories")?;
+        let mut records = OrderedJoin::new(
+            local.reader()?,
+            base.reader()?,
+            |record: &LocalRecord| record.path.clone(),
+            |record: &NamespaceRecord<FileExtentMap>| record.path.clone(),
+        );
+        let mut changed = false;
+        let mut root_seen = false;
+
+        while let Some(record) = records.next()? {
+            match record {
+                JoinItem::Left(local) => {
+                    changed = true;
+                    write_parent(&mut changed_directories, &local.path)?;
+                    write_new_local(&mut output, &mut renames, local)?;
+                }
+                JoinItem::Right(base_record) => {
+                    changed = true;
+                    write_parent(&mut changed_directories, &base_record.path)?;
+                    renames.removed_record(base_record)?;
+                }
+                JoinItem::Match(local, base_record) => {
+                    let path = local.path.clone();
+                    let base_node = base_record.value.ok_or_else(|| {
+                        Error::corrupt("scan replica", "base namespace contains a deletion")
+                    })?;
+                    if path.is_empty() {
+                        if base_node.node_id != base.root || base_node.kind() != NodeKind::Directory
+                        {
+                            return Err(Error::corrupt(
+                                "scan replica",
+                                "base namespace root is invalid",
+                            ));
+                        }
+                        root_seen = true;
+                    }
+                    if local.kind == base_node.kind() {
+                        changed |= !same_base_entry(&local, &base_node);
+                        let node = reuse_same_path(&local, base_node)?;
+                        output.write(&NamespaceRecord {
+                            path,
+                            value: Some(node),
+                        })?;
+                    } else {
+                        changed = true;
+                        write_parent(&mut changed_directories, &path)?;
+                        renames.removed_node(path.clone(), base_node)?;
+                        write_new_local(&mut output, &mut renames, local)?;
+                    }
+                }
+            }
+        }
+        if !root_seen {
+            return Err(Error::corrupt(
+                "scan replica",
+                "base namespace root is missing",
+            ));
+        }
+
+        let renames = renames.resolve(workspace)?;
+        if !changed {
+            return Ok(ScannedTree::Unchanged);
+        }
+        let cursor = next_cursor
+            .ok_or_else(|| Error::corrupt("scan replica", "Managed change sequence overflows"))?;
+        let entries = merge_path_records(workspace, &output.finish()?, &renames)?;
+        let changed_directories =
+            crate::work::sort(workspace, &changed_directories.finish()?, String::clone)?;
+        let entries =
+            advance_directory_generations(workspace, base, &entries, &changed_directories)?;
+        Ok(ScannedTree::Changed(Namespace {
+            volume_id: base.volume_id,
+            cursor,
+            root: base.root,
+            entries,
+        }))
+    }
+}
+
+fn merge_path_records(
+    workspace: &crate::work::WorkContext,
+    main: &crate::work::Spool<NamespaceRecord<FileExtentMap>>,
+    renames: &crate::work::Spool<NamespaceRecord<FileExtentMap>>,
+) -> Result<crate::work::Spool<NamespaceRecord<FileExtentMap>>, Error> {
+    let mut records = OrderedJoin::new(
+        main.reader()?,
+        renames.reader()?,
+        |record: &NamespaceRecord<FileExtentMap>| record.path.clone(),
+        |record: &NamespaceRecord<FileExtentMap>| record.path.clone(),
+    );
+    let mut output = workspace.writer("scanned-namespace-ordered")?;
+    while let Some(record) = records.next()? {
+        let record = match record {
+            JoinItem::Left(record) | JoinItem::Right(record) => record,
+            JoinItem::Match(_, _) => {
+                return Err(Error::corrupt(
+                    "scan replica",
+                    "one path has conflicting scan records",
+                ));
+            }
+        };
+        output.write(&record)?;
+    }
+    output.finish()
+}
+
+fn write_new_local(
+    output: &mut crate::work::SpoolWriter<NamespaceRecord<FileExtentMap>>,
+    renames: &mut RenameCandidates,
+    local: LocalRecord,
+) -> Result<(), Error> {
+    match local.kind {
+        NodeKind::Directory => output.write(&NamespaceRecord {
+            path: local.path,
+            value: Some(new_directory()),
+        }),
+        NodeKind::RegularFile => renames.local(local),
+    }
+}
+
+fn write_parent(output: &mut crate::work::SpoolWriter<String>, path: &str) -> Result<(), Error> {
+    if path.is_empty() {
+        return Ok(());
+    }
+    output.write(
+        &path
+            .rsplit_once('/')
+            .map_or("", |(parent, _)| parent)
+            .to_owned(),
+    )
+}
+
+fn advance_directory_generations(
+    workspace: &crate::work::WorkContext,
+    base: &Namespace<FileExtentMap>,
+    target: &crate::work::Spool<NamespaceRecord<FileExtentMap>>,
+    changed_directories: &crate::work::Spool<String>,
+) -> Result<crate::work::Spool<NamespaceRecord<FileExtentMap>>, Error> {
+    let mut base = base.reader()?;
+    let mut target = target.reader()?;
+    let mut changed = changed_directories.reader()?;
+    let mut base_record = base.next()?;
+    let mut changed_path = changed.next()?;
+    let mut output = workspace.writer("directory-generations")?;
+
+    while let Some(mut record) = target.next()? {
+        while base_record
+            .as_ref()
+            .is_some_and(|base| base.path < record.path)
+        {
+            base_record = base.next()?;
+        }
+        while changed_path
+            .as_ref()
+            .is_some_and(|changed| changed < &record.path)
+        {
+            let previous_changed = changed_path.take();
+            changed_path = changed.next()?;
+            while changed_path == previous_changed {
+                changed_path = changed.next()?;
+            }
+        }
+        if changed_path.as_deref() == Some(record.path.as_str())
+            && let (Some(base), Some(node)) = (base_record.as_ref(), record.value.as_mut())
+            && base.path == record.path
+            && base
+                .value
+                .as_ref()
+                .is_some_and(|base| base.node_id == node.node_id)
+            && let NamespaceValue::Directory { generation } = &mut node.value
+        {
+            *generation = next_generation(*generation)?;
+        }
+        output.write(&record)?;
+    }
+    output.finish()
+}
+
+fn reuse_same_path(
+    local: &LocalRecord,
+    base: NamespaceNode<FileExtentMap>,
+) -> Result<NamespaceNode<FileExtentMap>, Error> {
+    let attributes = NodeAttributes {
+        executable: local.executable,
+    };
+    match base.value {
+        NamespaceValue::Directory { generation } => Ok(NamespaceNode {
+            node_id: base.node_id,
+            generation: if base.attributes == attributes {
+                base.generation
+            } else {
+                next_generation(base.generation)?
+            },
+            attributes,
+            value: NamespaceValue::Directory { generation },
+        }),
+        NamespaceValue::RegularFile {
+            version,
+            content,
+            data,
+        } => {
+            let local_file = local
+                .file
+                .as_ref()
+                .expect("a local regular file has published content");
+            let local_fingerprint = local_file.content;
+            let unchanged_content = content == local_fingerprint;
+            Ok(NamespaceNode {
+                node_id: base.node_id,
+                generation: if unchanged_content && base.attributes == attributes {
+                    base.generation
+                } else {
+                    next_generation(base.generation)?
+                },
+                attributes,
+                value: if unchanged_content {
+                    NamespaceValue::RegularFile {
+                        version,
+                        content,
+                        data,
+                    }
+                } else {
+                    NamespaceValue::RegularFile {
+                        version: FileVersionId::generate(),
+                        content: local_fingerprint,
+                        data: local_file.data.clone(),
+                    }
+                },
+            })
+        }
+    }
+}
+
+fn same_base_entry(local: &LocalRecord, node: &NamespaceNode<FileExtentMap>) -> bool {
+    if node.kind() != local.kind || node.attributes.executable != local.executable {
+        return false;
+    }
+    match &node.value {
+        NamespaceValue::Directory { .. } => local.kind == NodeKind::Directory,
+        NamespaceValue::RegularFile { content, .. } => {
+            local.kind == NodeKind::RegularFile
+                && local.file.as_ref().map(|file| file.content) == Some(*content)
+        }
+    }
+}
+
+fn new_directory() -> NamespaceNode<FileExtentMap> {
+    NamespaceNode {
+        node_id: NodeId::generate(),
+        generation: 1,
+        attributes: NodeAttributes::default(),
+        value: NamespaceValue::Directory { generation: 1 },
+    }
+}
+
+pub(super) fn next_generation(generation: u64) -> Result<u64, Error> {
+    generation
+        .checked_add(1)
+        .ok_or_else(|| Error::corrupt("scan replica", "node generation overflows"))
+}

--- a/crates/core/src/sync/state.rs
+++ b/crates/core/src/sync/state.rs
@@ -178,4 +178,22 @@ impl ReplicaState {
         self.conflicts = 0;
         self.base_expired = false;
     }
+
+    pub(crate) fn begin_publication(
+        &mut self,
+        expected: NamespaceRevision,
+        target: NamespaceRevision,
+        operation_id: OperationId,
+        gc_epoch: GcEpoch,
+    ) -> Result<(), Error> {
+        self.phase = SyncPhase::Publishing {
+            target,
+            operation_id,
+            gc_epoch,
+        };
+        self.observed = expected;
+        self.conflicts = 0;
+        self.base_expired = false;
+        self.validate()
+    }
 }

--- a/crates/core/src/sync/transfer.rs
+++ b/crates/core/src/sync/transfer.rs
@@ -18,13 +18,106 @@
 use std::path::Path;
 
 use tokio::fs::File;
+use tokio::io::AsyncReadExt as _;
 
 use crate::Error;
-use crate::data::ReusableFile;
+use crate::data::{ContentReuseLookup, DataSegmentWriter, ReusableFile};
 use crate::filesystem::ContentRef;
-use crate::format::FileExtentMap;
+use crate::format::{FileExtentMap, FileRange, GcEpoch};
 use crate::volume::AccessFamily;
 use crate::volume::ManagedVolume;
+use serde::{Deserialize, Serialize};
+
+use super::replica::scan::LocalFile;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) enum FilePublication {
+    Complete,
+    Changed {
+        previous: Box<LocalFile>,
+        ranges: Vec<FileRange>,
+    },
+}
+
+pub(super) async fn publish_file<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    path: &Path,
+    publication: &FilePublication,
+    expected_length: u64,
+    known: &ContentReuseLookup,
+    gc_epoch: GcEpoch,
+) -> Result<(ContentRef, FileExtentMap), Error> {
+    let mut placement = volume.data_placement(gc_epoch, u64::MAX, None);
+    let result = publish_file_into(
+        volume,
+        &mut placement,
+        path,
+        publication,
+        expected_length,
+        known,
+    )
+    .await;
+    let (content, data, reused) = match result {
+        Ok(result) => result,
+        Err(error) => {
+            placement.abort().await;
+            return Err(error);
+        }
+    };
+    if reused || content.length() == 0 {
+        placement.abort().await;
+    } else {
+        placement.finish().await?;
+    }
+    Ok((content, data))
+}
+
+pub(super) async fn publish_file_into<A: AccessFamily>(
+    volume: &ManagedVolume<A>,
+    placement: &mut DataSegmentWriter<'_>,
+    path: &Path,
+    publication: &FilePublication,
+    expected_length: u64,
+    known: &ContentReuseLookup,
+) -> Result<(ContentRef, FileExtentMap, bool), Error> {
+    let mut file = File::open(path)
+        .await
+        .map_err(|error| Error::from_io("publish local file", Some(path), error))?;
+    let result = match publication {
+        FilePublication::Complete => {
+            let mut source = (&mut file).take(expected_length);
+            let result = volume
+                .publish_data_into(placement, &mut source, expected_length, known)
+                .await?;
+            drop(source);
+            let mut extra = [0_u8; 1];
+            if result.0.length() != expected_length
+                || file.read(&mut extra).await.map_err(|error| {
+                    Error::from_io("finish local file publication", Some(path), error)
+                })? != 0
+            {
+                return Err(Error::conflict(
+                    "publish local file",
+                    "local file changed while it was being published",
+                ));
+            }
+            Ok(result)
+        }
+        FilePublication::Changed { previous, ranges } => {
+            volume
+                .publish_patch_into(
+                    placement,
+                    &mut file,
+                    expected_length,
+                    (previous.content, previous.data.clone()),
+                    ranges,
+                    known,
+                )
+                .await
+        }
+    };
+    result.map_err(|error| error.with_context("path", path.display()))
+}
 
 pub(super) async fn materialize_file<A: AccessFamily>(
     volume: &ManagedVolume<A>,

--- a/crates/core/src/volume/open.rs
+++ b/crates/core/src/volume/open.rs
@@ -27,8 +27,8 @@ use crate::Error;
 use crate::ErrorKind;
 use crate::authority::{AuthorityAccess, AuthorityObservation, DefaultAuthorityAccess};
 use crate::data::{
-    CoreDataAccess, DataAccess, ExtentCodec, FilePartitioner, RangeReader, ReusableFile,
-    validate_file_map,
+    ContentReuseLookup, CoreDataAccess, DataAccess, DataSegmentWriter, ExtentCodec,
+    FilePartitioner, RangeReader, ReusableFile, validate_file_map,
 };
 use crate::filesystem::{ChangeCursor, ContentRef, NodeId, VolumeId};
 use crate::format::{
@@ -239,6 +239,29 @@ impl<A: AccessFamily> ManagedVolume<A> {
             .memory_target_bytes()
             .saturating_div(self.stream_concurrency)
             .max(1)
+    }
+
+    pub(crate) fn data_segment_target_bytes(&self) -> u64 {
+        self.format.file_data_layout().data_segment_target_bytes()
+    }
+
+    pub(crate) fn data_placement(
+        &self,
+        gc_epoch: GcEpoch,
+        target_bytes: u64,
+        stored_payload_bound: Option<u64>,
+    ) -> DataSegmentWriter<'_> {
+        crate::data::data_segments(
+            self.operator(),
+            gc_epoch,
+            target_bytes,
+            self.multipart_part_bytes,
+            stored_payload_bound,
+        )
+    }
+
+    pub(crate) fn stored_size_bound(&self, logical_bytes: u64) -> Option<u64> {
+        self.access.data().stored_size_bound(logical_bytes)
     }
 
     /// Create a volume in empty storage, or reopen it when the same layout exists.
@@ -467,6 +490,66 @@ impl<A: AccessFamily> ManagedVolume<A> {
                 head,
             )
             .await
+    }
+
+    pub(crate) async fn known_content(
+        &self,
+        workspace: &WorkContext,
+        observed: &ManagedObservation,
+        base: &Namespace<FileExtentMap>,
+    ) -> Result<ContentReuseLookup, Error> {
+        crate::data::reuse::build_known_content(
+            self.access.data(),
+            &self.operator,
+            workspace,
+            self.stream_concurrency,
+            &observed.namespace,
+            base,
+            self.format.file_data_layout().partitioning().is_some(),
+        )
+        .await
+    }
+
+    pub(crate) async fn publish_data_into(
+        &self,
+        placement: &mut DataSegmentWriter<'_>,
+        source: &mut (impl tokio::io::AsyncRead + Send + Unpin),
+        logical_bytes: u64,
+        known: &ContentReuseLookup,
+    ) -> Result<(ContentRef, FileExtentMap, bool), Error> {
+        crate::data::publish_file(
+            self.access.data(),
+            &self.operator,
+            self.multipart_part_bytes,
+            placement,
+            source,
+            logical_bytes,
+            known,
+        )
+        .await
+    }
+
+    pub(crate) async fn publish_patch_into(
+        &self,
+        placement: &mut DataSegmentWriter<'_>,
+        source: &mut (impl tokio::io::AsyncRead + Send + Unpin),
+        file_length: u64,
+        previous: (ContentRef, FileExtentMap),
+        ranges: &[crate::format::FileRange],
+        known: &ContentReuseLookup,
+    ) -> Result<(ContentRef, FileExtentMap, bool), Error> {
+        crate::data::publish_file_patch(
+            self.access.data(),
+            &self.operator,
+            self.multipart_part_bytes,
+            placement,
+            source,
+            file_length,
+            previous,
+            ranges,
+            known,
+        )
+        .await
     }
 
     pub(crate) async fn read_extent(

--- a/crates/core/src/work/mod.rs
+++ b/crates/core/src/work/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use compact::RunCompactor;
 pub(crate) use ordered::{
     AsyncOrderedMerge, AsyncOrderedRead, JoinItem, OrderedJoin, OrderedMerge, OrderedRead, Unique,
 };
-pub(crate) use sort::sort;
+pub(crate) use sort::{merge_sorted, sort};
 pub(crate) use spool::{Spool, SpoolReader, SpoolWriter};
 
 const MEBIBYTE: usize = 1024 * 1024;
@@ -88,6 +88,10 @@ impl WorkContext {
             })?),
             budget,
         })
+    }
+
+    pub fn path(&self) -> &std::path::Path {
+        self.workspace.path()
     }
 
     pub(super) fn sort_run_bytes(&self) -> usize {

--- a/crates/core/src/work/sort.rs
+++ b/crates/core/src/work/sort.rs
@@ -70,6 +70,23 @@ where
         .map_or_else(|| workspace.writer("sorted")?.finish(), Ok)
 }
 
+pub(crate) fn merge_sorted<T, K>(
+    workspace: &WorkContext,
+    inputs: Vec<Spool<T>>,
+    key: impl Fn(&T) -> K + Copy,
+) -> Result<Spool<T>, Error>
+where
+    T: DeserializeOwned + Serialize,
+    K: Ord,
+{
+    let mut runs = RunCompactor::new(workspace.fan_in());
+    for input in inputs {
+        runs.push(input, |runs| merge_runs(workspace, runs, key))?;
+    }
+    runs.finish(|runs| merge_runs(workspace, runs, key))?
+        .map_or_else(|| workspace.writer("merged")?.finish(), Ok)
+}
+
 fn merge_runs<T, K>(
     workspace: &WorkContext,
     runs: &[Spool<T>],


### PR DESCRIPTION
This PR publishes local replica changes to a managed volume.

It scans the replica, reuses stored content, writes new file data and namespace records, and publishes the resulting authority head. Convergence and recovery are out of scope.

Depends on #34. Part of #26.

Parts of this PR were written with AI assistance. I reviewed the code and take responsibility for it.

## Validation

- `cargo x lint`
- `cargo x check`
- `cargo x test`
- `cargo x licenses`
