### PR TITLE
feat: reconcile managed replicas

### DIFF
--- a/crates/core/src/sync/engine.rs
+++ b/crates/core/src/sync/engine.rs
@@ -16,19 +16,20 @@
 // under the License.
 
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::Error;
 use crate::filesystem::ChangeCursor;
 use crate::format::{FileExtentMap, NamespaceRevision};
-use crate::volume::{AccessFamily, CoreAccess, ManagedVolume, Namespace};
+use crate::volume::{AccessFamily, CoreAccess};
+use crate::volume::{ManagedVolume, Namespace};
 use crate::work::WorkContext;
 
 use super::FileChangeSetEntry;
 use super::ReplicaState;
 use super::install::install;
+use super::plan::{ConvergencePlan, SyncPlan};
 use super::replica::state_store::ReplicaStateFile;
-use super::scan::ScannedTree;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SyncOutcome {
@@ -43,6 +44,14 @@ impl SyncOutcome {
             conflict_paths: Vec::new(),
             published,
             sequence: revision.cursor().sequence(),
+        }
+    }
+
+    pub(super) fn conflicted(conflict_paths: Vec<String>, sequence: u64) -> Self {
+        Self {
+            conflict_paths,
+            published: false,
+            sequence,
         }
     }
 }
@@ -67,6 +76,11 @@ impl<A: AccessFamily> SyncEngine<A> {
 
     /// Synchronize immutable staged files using an exhaustive, base-bound set
     /// of regular-file mutations.
+    ///
+    /// Existing regular files omitted from `mutations` are trusted to retain
+    /// their previously synchronized content. Namespace additions, removals,
+    /// renames, type changes, and attributes are still observed from the local
+    /// directory.
     pub async fn sync_with_mutations(
         &self,
         root: &Path,
@@ -85,44 +99,78 @@ impl<A: AccessFamily> SyncEngine<A> {
         resolve_paths: &[String],
         mutations: Option<&[FileChangeSetEntry]>,
     ) -> Result<SyncOutcome, Error> {
-        validate_inputs(resolve_paths, mutations.unwrap_or_default())?;
-        let root = canonical_directory(root)?;
+        let mutation_input = mutations;
+        let mutations = mutations.unwrap_or_default();
+        let mutation_paths = mutations
+            .iter()
+            .map(|mutation| mutation.path.as_str())
+            .collect::<BTreeSet<_>>();
+        if mutation_paths.len() != mutations.len() {
+            return Err(Error::invalid(
+                "synchronize replica",
+                "one file has more than one mutation input",
+            ));
+        }
+        let resolved = resolve_paths.iter().cloned().collect::<BTreeSet<_>>();
+        if resolved.len() != resolve_paths.len() {
+            return Err(Error::invalid(
+                "synchronize replica",
+                "a conflict resolution path was provided more than once",
+            ));
+        }
+        let root = std::fs::canonicalize(root)
+            .map_err(|error| Error::from_io("open replica directory", Some(root), error))?;
+        if !root.is_dir() {
+            return Err(Error::invalid(
+                "synchronize replica",
+                "replica path is not a directory",
+            ));
+        }
         let workspace_directory = state_path
             .parent()
             .filter(|directory| !directory.as_os_str().is_empty())
             .unwrap_or_else(|| Path::new("."));
         let workspace = WorkContext::create_in(self.volume.work_budget(), workspace_directory)?;
+
         let (mut state_file, stored) = ReplicaStateFile::open(state_path)?;
-        validate_binding(stored.as_ref(), &root, &self.volume)?;
-
-        let requested = stored.as_ref().map(ReplicaState::resume_revision);
-        let (observed, loaded) = self
+        if let Some(state) = &stored {
+            if state.root() != root {
+                return Err(Error::invalid(
+                    "synchronize replica",
+                    "replica state belongs to a different local directory",
+                ));
+            }
+            if state.volume_id() != self.volume.id() {
+                return Err(Error::invalid(
+                    "synchronize replica",
+                    "replica state belongs to a different volume",
+                ));
+            }
+        }
+        let requested_revision = stored.as_ref().map(ReplicaState::resume_revision);
+        let (observed, loaded_revision) = self
             .volume
-            .observe_with_base_in(&workspace, requested)
+            .observe_with_base_in(&workspace, requested_revision)
             .await?;
-        validate_authority(stored.as_ref(), &observed, &self.volume)?;
-
+        if let Some(state) = &stored
+            && (state.authority_id() != observed.authority_id()
+                || state.authority_name() != self.volume.authority_name())
+        {
+            return Err(Error::invalid(
+                "synchronize replica",
+                "replica state belongs to a different namespace authority",
+            ));
+        }
         if let Some((target, published)) = stored.as_ref().and_then(ReplicaState::installation) {
-            let state = stored.expect("checked interrupted installation state");
-            let namespace = if observed.revision() == target {
-                &observed.namespace
-            } else {
-                loaded.as_ref().unwrap_or(&observed.namespace)
-            };
-            let revision = if observed.revision() == target {
-                target
-            } else {
-                observed.revision()
-            };
             return self
-                .install_and_advance(
+                .recover_install(
                     &workspace,
                     &root,
                     &mut state_file,
-                    state,
-                    namespace,
-                    revision,
-                    None,
+                    stored.expect("checked interrupted installation state"),
+                    observed,
+                    loaded_revision,
+                    target,
                     published,
                 )
                 .await;
@@ -131,6 +179,12 @@ impl<A: AccessFamily> SyncEngine<A> {
         let mut state = match stored {
             Some(state) => state,
             None => {
+                if !resolved.is_empty() {
+                    return Err(Error::invalid(
+                        "synchronize replica",
+                        "--resolve requires an unresolved conflict in replica state",
+                    ));
+                }
                 let state = ReplicaState::new(
                     root.clone(),
                     self.volume.id(),
@@ -159,83 +213,129 @@ impl<A: AccessFamily> SyncEngine<A> {
                 }
             }
         };
-        if state.has_pending() {
-            return Err(Error::unsupported(
-                "synchronize replica",
-                "pending publication requires recovery",
-            ));
-        }
-        if state.common_revision().cursor().sequence() == observed.revision().cursor().sequence()
-            && state.common_revision() != observed.revision()
-        {
-            return Err(Error::unsupported(
-                "synchronize replica",
-                "equivalent namespace rebasing requires convergence",
-            ));
-        }
-        if !observed.can_read_revision(state.common_revision()) {
-            return Err(Error::unsupported(
-                "synchronize replica",
-                "an expired replica base requires conservative reconciliation",
-            ));
-        }
-
-        let base = loaded.as_ref().unwrap_or(&observed.namespace);
-        let local = self
-            .scan(&workspace, &root, base, &observed, mutations)
-            .await?;
-        let remote_changed = state.common_revision() != observed.revision();
-        match (local, remote_changed) {
-            (ScannedTree::Unchanged, false) => {
-                Ok(SyncOutcome::complete(state.common_revision(), false))
-            }
-            (ScannedTree::Changed(target), false) => {
-                let target = self
-                    .publish_planned_files(&workspace, &root, &observed, &target, mutations)
-                    .await?;
-                let revision = self
-                    .prepare_and_commit(&workspace, &mut state_file, &mut state, &observed, &target)
-                    .await?;
-                Self::advance(&mut state_file, state, revision, true)
-            }
-            (ScannedTree::Unchanged, true) => {
-                self.install_and_advance(
+        if state.pending_publication().is_some() {
+            return self
+                .recover_pending(
                     &workspace,
                     &root,
                     &mut state_file,
                     state,
-                    &observed.namespace,
-                    observed.revision(),
-                    Some(base),
-                    false,
+                    observed,
+                    loaded_revision,
+                )
+                .await;
+        }
+
+        if state.common_revision() != observed.revision()
+            && state.common_revision().cursor().sequence()
+                == observed.revision().cursor().sequence()
+        {
+            state.rebase_equivalent(observed.revision())?;
+            state_file.persist(&state)?;
+        }
+        if !observed.can_read_revision(state.common_revision()) {
+            return self
+                .conservative_rebase(
+                    &workspace,
+                    &root,
+                    &mut state_file,
+                    state,
+                    observed,
+                    &resolved,
+                )
+                .await;
+        }
+
+        let base = loaded_revision.as_ref().unwrap_or(&observed.namespace);
+        let local = self
+            .scan(&workspace, &root, base, &observed, mutation_input)
+            .await?;
+        match SyncPlan::build(
+            base,
+            local,
+            &observed.namespace,
+            observed.revision(),
+            &resolved,
+            &workspace,
+        )? {
+            SyncPlan::Unchanged => Ok(SyncOutcome::complete(state.common_revision(), false)),
+            SyncPlan::Conflicted(paths) => {
+                Self::retain_conflicts(&mut state_file, state, paths, observed.revision(), false)
+            }
+            SyncPlan::Converge(plan) => {
+                self.converge(
+                    &workspace,
+                    &root,
+                    &mut state_file,
+                    state,
+                    &observed,
+                    plan,
+                    mutation_input,
                 )
                 .await
             }
-            (ScannedTree::Changed(_), true) => Err(Error::unsupported(
-                "synchronize replica",
-                "concurrent local and remote changes require reconciliation",
-            )),
         }
     }
 
-    async fn install_and_advance(
+    pub(super) async fn converge(
         &self,
         workspace: &WorkContext,
         root: &Path,
         state_file: &mut ReplicaStateFile,
         mut state: ReplicaState,
-        namespace: &Namespace<FileExtentMap>,
-        revision: NamespaceRevision,
-        current: Option<&Namespace<FileExtentMap>>,
-        published: bool,
+        observed: &crate::volume::ManagedObservation,
+        plan: ConvergencePlan,
+        mutations: Option<&[FileChangeSetEntry]>,
     ) -> Result<SyncOutcome, Error> {
-        state.begin_install(revision, published);
-        state_file.persist(&state)?;
-        install(workspace, root, namespace, &self.volume, current).await?;
+        let published = plan.committed.is_none();
+        let target = if published {
+            self.publish_planned_files(workspace, root, observed, &plan.target, mutations)
+                .await?
+        } else {
+            plan.target
+        };
+        let revision = match plan.committed {
+            Some(revision) => revision,
+            None => {
+                self.prepare_and_commit(workspace, state_file, &mut state, observed, &target)
+                    .await?
+            }
+        };
+        if let Some(current) = plan.install_from {
+            return self
+                .install_and_advance(
+                    workspace,
+                    root,
+                    state_file,
+                    state,
+                    &target,
+                    revision,
+                    Some(&current),
+                    published,
+                )
+                .await;
+        }
         Self::advance(state_file, state, revision, published)
     }
 
-    fn advance(
+    pub(super) async fn install_and_advance(
+        &self,
+        workspace: &WorkContext,
+        root: &Path,
+        state_file: &mut ReplicaStateFile,
+        mut state: ReplicaState,
+        target: &Namespace<FileExtentMap>,
+        target_revision: NamespaceRevision,
+        current: Option<&Namespace<FileExtentMap>>,
+        published: bool,
+    ) -> Result<SyncOutcome, Error> {
+        state.begin_install(target_revision, published);
+        state_file.persist(&state)?;
+        install(workspace, root, target, &self.volume, current).await?;
+        Self::advance(state_file, state, target_revision, published)
+    }
+
+    pub(super) fn advance(
         state_file: &mut ReplicaStateFile,
         mut state: ReplicaState,
         revision: NamespaceRevision,
@@ -245,81 +345,21 @@ impl<A: AccessFamily> SyncEngine<A> {
         state_file.persist(&state)?;
         Ok(SyncOutcome::complete(revision, published))
     }
-}
 
-fn validate_inputs(
-    resolve_paths: &[String],
-    mutations: &[FileChangeSetEntry],
-) -> Result<(), Error> {
-    if !resolve_paths.is_empty() {
-        return Err(Error::unsupported(
-            "synchronize replica",
-            "conflict resolution requires reconciliation",
-        ));
+    pub(super) fn retain_conflicts(
+        state_file: &mut ReplicaStateFile,
+        mut state: ReplicaState,
+        paths: Vec<String>,
+        remote: NamespaceRevision,
+        base_expired: bool,
+    ) -> Result<SyncOutcome, Error> {
+        state.retain_conflicts(paths.len(), remote, base_expired);
+        state_file.persist(&state)?;
+        Ok(SyncOutcome::conflicted(
+            paths,
+            state.common_revision().cursor().sequence(),
+        ))
     }
-    let paths = mutations
-        .iter()
-        .map(|mutation| mutation.path.as_str())
-        .collect::<BTreeSet<_>>();
-    if paths.len() != mutations.len() {
-        return Err(Error::invalid(
-            "synchronize replica",
-            "one file has more than one mutation input",
-        ));
-    }
-    Ok(())
-}
-
-fn canonical_directory(root: &Path) -> Result<PathBuf, Error> {
-    let root = std::fs::canonicalize(root)
-        .map_err(|error| Error::from_io("open replica directory", Some(root), error))?;
-    if !root.is_dir() {
-        return Err(Error::invalid(
-            "synchronize replica",
-            "replica path is not a directory",
-        ));
-    }
-    Ok(root)
-}
-
-fn validate_binding<A: AccessFamily>(
-    state: Option<&ReplicaState>,
-    root: &Path,
-    volume: &ManagedVolume<A>,
-) -> Result<(), Error> {
-    let Some(state) = state else {
-        return Ok(());
-    };
-    if state.root() != root {
-        return Err(Error::invalid(
-            "synchronize replica",
-            "replica state belongs to a different local directory",
-        ));
-    }
-    if state.volume_id() != volume.id() {
-        return Err(Error::invalid(
-            "synchronize replica",
-            "replica state belongs to a different volume",
-        ));
-    }
-    Ok(())
-}
-
-fn validate_authority<A: AccessFamily>(
-    state: Option<&ReplicaState>,
-    observed: &crate::volume::ManagedObservation,
-    volume: &ManagedVolume<A>,
-) -> Result<(), Error> {
-    if let Some(state) = state
-        && (state.authority_id() != observed.authority_id()
-            || state.authority_name() != volume.authority_name())
-    {
-        return Err(Error::invalid(
-            "synchronize replica",
-            "replica state belongs to a different namespace authority",
-        ));
-    }
-    Ok(())
 }
 
 fn require_empty(root: &Path) -> Result<(), Error> {

--- a/crates/core/src/sync/mod.rs
+++ b/crates/core/src/sync/mod.rs
@@ -15,14 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Public request and durable replica-state contracts for Managed Sync.
+//! SANSIO Managed Sync: observe, plan, publish, CAS, install.
 
 mod engine;
 mod input;
 mod install;
+mod plan;
 mod publish;
+mod reconcile;
+mod recovery;
 mod rename;
-mod replica;
+pub(crate) mod replica;
 mod scan;
 mod segment_install;
 mod state;

--- a/crates/core/src/sync/plan.rs
+++ b/crates/core/src/sync/plan.rs
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Deterministic projection from observed trees to one convergence plan.
+
+use std::collections::BTreeSet;
+
+use crate::Error;
+use crate::format::{FileExtentMap, NamespaceRevision};
+use crate::volume::Namespace;
+use crate::work::WorkContext;
+
+use super::reconcile::{ReconcilePlan, reconcile};
+use super::scan::ScannedTree;
+
+pub(super) enum SyncPlan {
+    Unchanged,
+    Conflicted(Vec<String>),
+    Converge(ConvergencePlan),
+}
+
+pub(super) struct ConvergencePlan {
+    pub(super) target: Namespace<FileExtentMap>,
+    pub(super) committed: Option<NamespaceRevision>,
+    pub(super) install_from: Option<Namespace<FileExtentMap>>,
+}
+
+impl SyncPlan {
+    pub(super) fn build(
+        base: &Namespace<FileExtentMap>,
+        local: ScannedTree,
+        remote: &Namespace<FileExtentMap>,
+        remote_revision: NamespaceRevision,
+        resolved: &BTreeSet<String>,
+        workspace: &WorkContext,
+    ) -> Result<Self, Error> {
+        let remote_changed = remote_revision.cursor() != base.cursor;
+        match (local, remote_changed) {
+            (ScannedTree::Unchanged, false) => Ok(Self::Unchanged),
+            (ScannedTree::Changed(target), false) => {
+                require_no_resolutions(resolved)?;
+                Ok(Self::Converge(ConvergencePlan {
+                    target,
+                    committed: None,
+                    install_from: None,
+                }))
+            }
+            (ScannedTree::Unchanged, true) => {
+                require_no_resolutions(resolved)?;
+                Ok(Self::Converge(ConvergencePlan {
+                    target: remote.clone(),
+                    committed: Some(remote_revision),
+                    install_from: Some(base.clone()),
+                }))
+            }
+            (ScannedTree::Changed(local), true) => {
+                match reconcile(base, &local, remote, resolved, workspace)? {
+                    ReconcilePlan::Conflicted(conflicts) => Ok(Self::Conflicted(conflicts)),
+                    ReconcilePlan::Publish(target) => Ok(Self::Converge(ConvergencePlan {
+                        target,
+                        committed: None,
+                        install_from: Some(local),
+                    })),
+                    ReconcilePlan::Remote => Ok(Self::Converge(ConvergencePlan {
+                        target: remote.clone(),
+                        committed: Some(remote_revision),
+                        install_from: Some(local),
+                    })),
+                }
+            }
+        }
+    }
+}
+
+fn require_no_resolutions(resolved: &BTreeSet<String>) -> Result<(), Error> {
+    if !resolved.is_empty() {
+        return Err(Error::invalid(
+            "synchronize replica",
+            "--resolve requires a current local and remote conflict",
+        ));
+    }
+    Ok(())
+}

--- a/crates/core/src/sync/reconcile.rs
+++ b/crates/core/src/sync/reconcile.rs
@@ -1,0 +1,322 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::BTreeSet;
+
+use crate::Error;
+use crate::filesystem::{NamespaceNode, NamespaceRecord, NodeKind};
+use crate::format::FileExtentMap;
+use crate::volume::Namespace;
+use crate::work::OrderedMerge;
+use crate::work::WorkContext;
+
+pub(crate) enum ReconcilePlan {
+    Conflicted(Vec<String>),
+    Remote,
+    Publish(Namespace<FileExtentMap>),
+}
+
+pub(crate) fn changed_paths(
+    base: &Namespace<FileExtentMap>,
+    side: &Namespace<FileExtentMap>,
+) -> Result<BTreeSet<String>, Error> {
+    require_same_volume(base, side)?;
+    let mut records = OrderedMerge::from_readers(
+        vec![base.reader()?, side.reader()?],
+        |record: &NamespaceRecord<FileExtentMap>| Ok(record.path.clone()),
+    )?;
+    let mut changed = BTreeSet::new();
+    while let Some((path, [base_record, side_record])) =
+        records.reduce_next_group([None, None], |group, source, record| {
+            group[source] = Some(record);
+            Ok(())
+        })?
+    {
+        if !same_entry(base_record.as_ref(), side_record.as_ref()) {
+            changed.insert(path);
+        }
+    }
+    Ok(changed)
+}
+
+pub(crate) fn reconcile(
+    common: &Namespace<FileExtentMap>,
+    local: &Namespace<FileExtentMap>,
+    remote: &Namespace<FileExtentMap>,
+    resolved: &BTreeSet<String>,
+    workspace: &WorkContext,
+) -> Result<ReconcilePlan, Error> {
+    require_same_volume(common, local)?;
+    require_same_volume(common, remote)?;
+    if common.cursor.sequence() > remote.cursor.sequence() {
+        return Err(Error::corrupt(
+            "reconcile replica",
+            "reconciliation ancestry is invalid",
+        ));
+    }
+
+    let directory_conflicts = directory_conflicts(common, local, remote)?;
+    let mut target = workspace.writer("reconciled-namespace")?;
+    let mut records = OrderedMerge::from_readers(
+        vec![common.reader()?, local.reader()?, remote.reader()?],
+        |record: &NamespaceRecord<FileExtentMap>| Ok(record.path.clone()),
+    )?;
+    let mut directory_conflicts = directory_conflicts.into_iter().peekable();
+    let mut active_directories = Vec::<(String, bool)>::new();
+    let mut unresolved_directories = 0_usize;
+    let mut conflicts = Vec::new();
+    let mut resolved_conflicts = BTreeSet::new();
+    let mut differs_from_remote = false;
+
+    while let Some((path, [common_record, local_record, remote_record])) = records
+        .reduce_next_group([None, None, None], |group, source, record| {
+            group[source] = Some(record);
+            Ok(())
+        })?
+    {
+        while active_directories
+            .last()
+            .is_some_and(|(directory, _)| path != *directory && !is_descendant(directory, &path))
+        {
+            if !active_directories.pop().expect("active directory exists").1 {
+                unresolved_directories -= 1;
+            }
+        }
+        while directory_conflicts
+            .peek()
+            .is_some_and(|directory| directory == &path)
+        {
+            let directory = directory_conflicts
+                .next()
+                .expect("peeked directory conflict");
+            let is_resolved = resolved.contains(&directory);
+            if is_resolved {
+                resolved_conflicts.insert(directory.clone());
+            } else {
+                unresolved_directories += 1;
+            }
+            active_directories.push((directory, is_resolved));
+        }
+
+        let remote_comparison = remote_record.clone();
+        let blocked = unresolved_directories != 0;
+        let forced_local = !blocked && !active_directories.is_empty();
+
+        let selected = if blocked {
+            if active_directories
+                .iter()
+                .any(|(directory, is_resolved)| directory == &path && !is_resolved)
+            {
+                conflicts.push(path.clone());
+            }
+            None
+        } else if forced_local {
+            local_record.and_then(live_record)
+        } else {
+            let local_changed = !same_entry(common_record.as_ref(), local_record.as_ref());
+            let remote_changed = !same_entry(common_record.as_ref(), remote_record.as_ref());
+            match (local_changed, remote_changed) {
+                (false, false) | (false, true) => remote_record.and_then(live_record),
+                (true, false) => local_record.and_then(live_record),
+                (true, true) if same_entry(local_record.as_ref(), remote_record.as_ref()) => {
+                    remote_record.and_then(live_record)
+                }
+                (true, true) if resolved.contains(&path) => {
+                    resolved_conflicts.insert(path.clone());
+                    local_record.and_then(live_record)
+                }
+                (true, true) => {
+                    conflicts.push(path.clone());
+                    None
+                }
+            }
+        };
+
+        if !same_entry(selected.as_ref(), remote_comparison.as_ref()) {
+            differs_from_remote = true;
+        }
+        if let Some(record) = selected {
+            target.write(&record)?;
+        }
+    }
+
+    if resolved_conflicts != *resolved {
+        let missing = resolved
+            .difference(&resolved_conflicts)
+            .cloned()
+            .collect::<Vec<_>>();
+        return Err(Error::invalid(
+            "synchronize replica",
+            format!("no unresolved conflict exists for {missing:?}"),
+        ));
+    }
+
+    conflicts.sort();
+    conflicts.dedup();
+    if !conflicts.is_empty() {
+        return Ok(ReconcilePlan::Conflicted(conflicts));
+    }
+    if !differs_from_remote {
+        return Ok(ReconcilePlan::Remote);
+    }
+
+    let sequence =
+        remote.cursor.sequence().checked_add(1).ok_or_else(|| {
+            Error::corrupt("reconcile replica", "Managed change sequence overflows")
+        })?;
+    Ok(ReconcilePlan::Publish(Namespace {
+        volume_id: remote.volume_id,
+        cursor: crate::filesystem::ChangeCursor::from_sequence(sequence),
+        root: remote.root,
+        entries: target.finish()?,
+    }))
+}
+
+fn directory_conflicts(
+    common: &Namespace<FileExtentMap>,
+    local: &Namespace<FileExtentMap>,
+    remote: &Namespace<FileExtentMap>,
+) -> Result<Vec<String>, Error> {
+    let mut records = OrderedMerge::from_readers(
+        vec![common.reader()?, local.reader()?, remote.reader()?],
+        |record: &NamespaceRecord<FileExtentMap>| Ok(record.path.clone()),
+    )?;
+    let mut pending = Vec::<DirectoryWatch>::new();
+    let mut conflicts = Vec::new();
+    let mut local_changes = 0_u64;
+    let mut remote_changes = 0_u64;
+
+    while let Some((path, [common_record, local_record, remote_record])) = records
+        .reduce_next_group([None, None, None], |group, source, record| {
+            group[source] = Some(record);
+            Ok(())
+        })?
+    {
+        while pending
+            .last()
+            .is_some_and(|watch| path != watch.path && !is_descendant(&watch.path, &path))
+        {
+            let watch = pending.pop().expect("pending directory exists");
+            if watch.changed(local_changes, remote_changes) {
+                conflicts.push(watch.path);
+            }
+        }
+
+        let local_changed = !same_entry(common_record.as_ref(), local_record.as_ref());
+        let remote_changed = !same_entry(common_record.as_ref(), remote_record.as_ref());
+        if local_changed {
+            local_changes = local_changes.saturating_add(1);
+        }
+        if remote_changed {
+            remote_changes = remote_changes.saturating_add(1);
+        }
+
+        if kind(common_record.as_ref()) == Some(NodeKind::Directory) {
+            let local_kept = kind(local_record.as_ref()) == Some(NodeKind::Directory);
+            let remote_kept = kind(remote_record.as_ref()) == Some(NodeKind::Directory);
+            if !local_kept && remote_kept {
+                pending.push(DirectoryWatch {
+                    path: path.clone(),
+                    side: WatchedSide::Remote,
+                    baseline: remote_changes,
+                });
+            } else if local_kept && !remote_kept {
+                pending.push(DirectoryWatch {
+                    path,
+                    side: WatchedSide::Local,
+                    baseline: local_changes,
+                });
+            }
+        }
+    }
+    conflicts.extend(pending.into_iter().filter_map(|watch| {
+        watch
+            .changed(local_changes, remote_changes)
+            .then_some(watch.path)
+    }));
+    conflicts.sort();
+    conflicts.dedup();
+    Ok(conflicts)
+}
+
+#[derive(Clone, Copy)]
+enum WatchedSide {
+    Local,
+    Remote,
+}
+
+struct DirectoryWatch {
+    path: String,
+    side: WatchedSide,
+    baseline: u64,
+}
+
+impl DirectoryWatch {
+    fn changed(&self, local_changes: u64, remote_changes: u64) -> bool {
+        match self.side {
+            WatchedSide::Local => local_changes != self.baseline,
+            WatchedSide::Remote => remote_changes != self.baseline,
+        }
+    }
+}
+
+fn same_entry<L, R>(left: Option<&NamespaceRecord<L>>, right: Option<&NamespaceRecord<R>>) -> bool {
+    match (
+        left.and_then(|record| record.value.as_ref()),
+        right.and_then(|record| record.value.as_ref()),
+    ) {
+        (None, None) => true,
+        (Some(left), Some(right)) => same_node(left, right),
+        _ => false,
+    }
+}
+
+fn same_node<L, R>(left: &NamespaceNode<L>, right: &NamespaceNode<R>) -> bool {
+    left.node_id == right.node_id
+        && left.attributes == right.attributes
+        && match (left.file(), right.file()) {
+            (None, None) => true,
+            (Some((left, _, _)), Some((right, _, _))) => left == right,
+            _ => false,
+        }
+}
+
+fn kind<C>(record: Option<&NamespaceRecord<C>>) -> Option<NodeKind> {
+    record.and_then(|record| record.value.as_ref().map(NamespaceNode::kind))
+}
+
+fn live_record(record: NamespaceRecord<FileExtentMap>) -> Option<NamespaceRecord<FileExtentMap>> {
+    record.value.is_some().then_some(record)
+}
+
+fn require_same_volume<L, R>(left: &Namespace<L>, right: &Namespace<R>) -> Result<(), Error> {
+    if left.volume_id != right.volume_id || left.root != right.root {
+        return Err(Error::corrupt(
+            "reconcile replica",
+            "reconciliation namespaces belong to different volumes",
+        ));
+    }
+    Ok(())
+}
+
+fn is_descendant(directory: &str, path: &str) -> bool {
+    if directory.is_empty() {
+        return !path.is_empty();
+    }
+    path.strip_prefix(directory)
+        .is_some_and(|suffix| suffix.starts_with('/'))
+}

--- a/crates/core/src/sync/recovery.rs
+++ b/crates/core/src/sync/recovery.rs
@@ -1,0 +1,219 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Recovery paths for interrupted or no-longer-readable Sync state.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use crate::Error;
+use crate::format::{FileExtentMap, NamespaceRevision};
+use crate::volume::AccessFamily;
+use crate::volume::{ManagedObservation, Namespace};
+use crate::work::WorkContext;
+
+use super::ReplicaState;
+use super::engine::{SyncEngine, SyncOutcome};
+use super::plan::ConvergencePlan;
+use super::reconcile::changed_paths;
+use super::replica::state_store::ReplicaStateFile;
+use super::scan::ScannedTree;
+
+impl<A: AccessFamily> SyncEngine<A> {
+    pub(super) async fn recover_install(
+        &self,
+        workspace: &WorkContext,
+        root: &Path,
+        state_file: &mut ReplicaStateFile,
+        state: ReplicaState,
+        observed: ManagedObservation,
+        loaded_target: Option<Namespace<FileExtentMap>>,
+        target: NamespaceRevision,
+        published: bool,
+    ) -> Result<SyncOutcome, Error> {
+        let (target_namespace, target_revision) = if observed.revision() == target {
+            (&observed.namespace, target)
+        } else if let Some(target_namespace) = loaded_target.as_ref() {
+            (target_namespace, target)
+        } else {
+            (&observed.namespace, observed.revision())
+        };
+        self.install_and_advance(
+            workspace,
+            root,
+            state_file,
+            state,
+            target_namespace,
+            target_revision,
+            None,
+            published,
+        )
+        .await
+    }
+
+    pub(super) async fn recover_pending(
+        &self,
+        workspace: &WorkContext,
+        root: &Path,
+        state_file: &mut ReplicaStateFile,
+        mut state: ReplicaState,
+        observed: ManagedObservation,
+        loaded_target: Option<Namespace<FileExtentMap>>,
+    ) -> Result<SyncOutcome, Error> {
+        let (expected, target, operation, gc_epoch) = state
+            .pending_publication()
+            .expect("pending state has publication references");
+        if observed.revision() == target
+            || self
+                .volume
+                .operation_committed(operation, target.cursor(), &observed)
+                .await?
+        {
+            return self
+                .install_committed_publication(
+                    workspace,
+                    root,
+                    state_file,
+                    state,
+                    observed,
+                    loaded_target,
+                    expected,
+                    target,
+                )
+                .await;
+        }
+        if observed.gc_epoch() != gc_epoch {
+            state.cancel_pending(observed.revision());
+            state_file.persist(&state)?;
+            return Err(Error::invalid(
+                "synchronize replica",
+                "pending publication was invalidated by data collection; repeat sync to prepare it again",
+            ));
+        }
+        if observed.revision() != expected {
+            state.cancel_pending(observed.revision());
+            state_file.persist(&state)?;
+            return Err(Error::invalid(
+                "synchronize replica",
+                "pending publication conflicted with a newer remote change; repeat sync to reconcile",
+            ));
+        }
+        self.volume
+            .commit_publication(&observed, target, operation)
+            .await?;
+        self.install_committed_publication(
+            workspace,
+            root,
+            state_file,
+            state,
+            observed,
+            loaded_target,
+            expected,
+            target,
+        )
+        .await
+    }
+
+    async fn install_committed_publication(
+        &self,
+        workspace: &WorkContext,
+        root: &Path,
+        state_file: &mut ReplicaStateFile,
+        state: ReplicaState,
+        observed: ManagedObservation,
+        loaded_expected: Option<Namespace<FileExtentMap>>,
+        expected: NamespaceRevision,
+        target: NamespaceRevision,
+    ) -> Result<SyncOutcome, Error> {
+        let current = if observed.revision() == expected {
+            Some(&observed.namespace)
+        } else {
+            loaded_expected.as_ref()
+        };
+        if observed.revision().cursor() >= target.cursor() {
+            return self
+                .install_and_advance(
+                    workspace,
+                    root,
+                    state_file,
+                    state,
+                    &observed.namespace,
+                    observed.revision(),
+                    current,
+                    true,
+                )
+                .await;
+        }
+        let target_namespace = self.volume.read_namespace_in(workspace, target).await?;
+        self.install_and_advance(
+            workspace,
+            root,
+            state_file,
+            state,
+            &target_namespace,
+            target,
+            current,
+            true,
+        )
+        .await
+    }
+
+    pub(super) async fn conservative_rebase(
+        &self,
+        workspace: &WorkContext,
+        root: &Path,
+        state_file: &mut ReplicaStateFile,
+        state: ReplicaState,
+        observed: ManagedObservation,
+        resolved: &BTreeSet<String>,
+    ) -> Result<SyncOutcome, Error> {
+        let local = match self
+            .scan(workspace, root, &observed.namespace, &observed, None)
+            .await?
+        {
+            ScannedTree::Unchanged => {
+                return Self::advance(state_file, state, observed.revision(), false);
+            }
+            ScannedTree::Changed(namespace) => namespace,
+        };
+        let ambiguous = changed_paths(&observed.namespace, &local)?;
+        if resolved != &ambiguous {
+            let conflict_paths = ambiguous.into_iter().collect::<Vec<_>>();
+            return Self::retain_conflicts(
+                state_file,
+                state,
+                conflict_paths,
+                observed.revision(),
+                true,
+            );
+        }
+        self.converge(
+            workspace,
+            root,
+            state_file,
+            state,
+            &observed,
+            ConvergencePlan {
+                target: local,
+                committed: None,
+                install_from: None,
+            },
+            None,
+        )
+        .await
+    }
+}

--- a/crates/core/src/sync/replica/mod.rs
+++ b/crates/core/src/sync/replica/mod.rs
@@ -17,4 +17,4 @@
 
 pub(crate) mod fs;
 pub(crate) mod scan;
-pub(super) mod state_store;
+pub(crate) mod state_store;

--- a/crates/core/src/sync/state.rs
+++ b/crates/core/src/sync/state.rs
@@ -150,6 +150,19 @@ impl ReplicaState {
         self.base_expired
     }
 
+    pub(crate) const fn pending_publication(
+        &self,
+    ) -> Option<(NamespaceRevision, NamespaceRevision, OperationId, GcEpoch)> {
+        match self.phase {
+            SyncPhase::Publishing {
+                target,
+                operation_id,
+                gc_epoch,
+            } => Some((self.observed, target, operation_id, gc_epoch)),
+            _ => None,
+        }
+    }
+
     pub(crate) const fn installation(&self) -> Option<(NamespaceRevision, bool)> {
         match self.phase {
             SyncPhase::Installing { published } => Some((self.observed, published)),
@@ -160,7 +173,8 @@ impl ReplicaState {
     pub(crate) const fn resume_revision(&self) -> NamespaceRevision {
         match self.phase {
             SyncPhase::Clean => self.common,
-            SyncPhase::Publishing { .. } | SyncPhase::Installing { .. } => self.observed,
+            SyncPhase::Publishing { .. } => self.observed,
+            SyncPhase::Installing { .. } => self.observed,
         }
     }
 
@@ -172,11 +186,18 @@ impl ReplicaState {
         self.base_expired = false;
     }
 
-    pub(crate) fn begin_install(&mut self, target: NamespaceRevision, published: bool) {
-        self.phase = SyncPhase::Installing { published };
-        self.observed = target;
-        self.conflicts = 0;
-        self.base_expired = false;
+    pub(crate) fn rebase_equivalent(&mut self, common: NamespaceRevision) -> Result<(), Error> {
+        if !matches!(self.phase, SyncPhase::Clean)
+            || common.cursor().sequence() != self.common.cursor().sequence()
+        {
+            return Err(Error::corrupt(
+                "synchronize replica",
+                "equivalent namespace rebase changed the logical cursor",
+            ));
+        }
+        self.common = common;
+        self.observed = common;
+        self.validate()
     }
 
     pub(crate) fn begin_publication(
@@ -195,5 +216,33 @@ impl ReplicaState {
         self.conflicts = 0;
         self.base_expired = false;
         self.validate()
+    }
+
+    pub(crate) fn begin_install(&mut self, target: NamespaceRevision, published: bool) {
+        self.phase = SyncPhase::Installing { published };
+        self.observed = target;
+        self.conflicts = 0;
+        self.base_expired = false;
+    }
+
+    pub(crate) fn retain_conflicts(
+        &mut self,
+        conflicts: usize,
+        remote: NamespaceRevision,
+        base_expired: bool,
+    ) {
+        self.phase = SyncPhase::Clean;
+        self.conflicts = conflicts.try_into().unwrap_or(u64::MAX);
+        self.observed = remote;
+        self.base_expired = base_expired;
+    }
+
+    pub(crate) fn cancel_pending(&mut self, remote: NamespaceRevision) {
+        self.phase = SyncPhase::Clean;
+        if remote.cursor().sequence() == self.common.cursor().sequence() {
+            self.common = remote;
+        }
+        self.observed = remote;
+        self.base_expired = false;
     }
 }


### PR DESCRIPTION
This PR completes replica convergence.

It plans and reconciles concurrent local and remote changes, records recovery state, and resumes interrupted work. The CLI is out of scope.

Depends on #35. Part of #26.

Parts of this PR were written with AI assistance. I reviewed the code and take responsibility for it.

## Validation

- `cargo x lint`
- `cargo x check`
- `cargo x test`
- `cargo x licenses`
