### PR TITLE
feat: expose managed volume commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +361,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -429,6 +458,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -617,6 +655,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1068,7 +1112,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c709842c4ce65cb91e2666ad5319dfc1efc3af0d34f02075eddca9000d9f8afb"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.17.1",
  "slab",
 ]
 
@@ -1092,6 +1136,15 @@ dependencies = [
 [[package]]
 name = "ofs"
 version = "0.0.24"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ofs-core",
+ "opendal",
+ "serde",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "ofs-core"
@@ -1150,6 +1203,7 @@ dependencies = [
  "opendal-layer-retry",
  "opendal-layer-timeout",
  "opendal-service-fs",
+ "opendal-service-s3",
 ]
 
 [[package]]
@@ -1169,7 +1223,7 @@ dependencies = [
  "md-5",
  "mea",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.39.4",
  "reqsign-core",
  "reqwest",
  "serde",
@@ -1238,10 +1292,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "opendal-service-s3"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313d46c9f5ae70bca26b7c3e3fbb9b639292625f28af73aa016f47e788af9deb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc32c",
+ "http",
+ "log",
+ "md-5",
+ "opendal-core",
+ "quick-xml 0.39.4",
+ "reqsign-aws-v4",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "serde",
+ "url",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1299,6 +1384,16 @@ name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -1403,6 +1498,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqsign-aws-core"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac4749b7dfa7bfaccd01eb03e9dc795ed37e3f20d6f0f38e2c67ee85ad6bc86"
+dependencies = [
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "http",
+ "log",
+ "percent-encoding",
+ "quick-xml 0.41.0",
+ "reqsign-core",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sha1",
+]
+
+[[package]]
+name = "reqsign-aws-v4"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff250f0fd0b913fbd565e405acc553da0f13bde30bfb5403178c9d0313cdc15f"
+dependencies = [
+ "bytes",
+ "http",
+ "log",
+ "quick-xml 0.41.0",
+ "reqsign-aws-core",
+ "reqsign-core",
+ "serde",
+]
+
+[[package]]
 name = "reqsign-core"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1553,17 @@ dependencies = [
  "sha1",
  "sha2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "reqsign-file-read-tokio"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3235df90a6bca681aa47dd86f2393d122a6d77042aa8a7c81e218cd45c5bfc0"
+dependencies = [
+ "anyhow",
+ "reqsign-core",
+ "tokio",
 ]
 
 [[package]]
@@ -1474,6 +1616,16 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -1586,6 +1738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,6 +1831,18 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1838,6 +2008,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,19 @@ publish = false
 repository.workspace = true
 rust-version.workspace = true
 
+[[bin]]
+name = "ofs"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+clap.workspace = true
+ofs-core = { path = "crates/core" }
+opendal = { version = "0.57.0", features = ["services-fs", "services-memory", "services-s3"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
 [workspace]
 members = [".", "crates/core", "crates/managed-format", "xtask"]
 resolver = "3"
@@ -43,7 +56,7 @@ rust-version = "1.91.0"
 
 [workspace.dependencies]
 blake3 = "1"
-clap = { version = "4.6.5", features = ["derive"] }
+clap = { version = "4.6.5", features = ["derive", "env"] }
 futures = "0.3"
 tokio-util = { version = "0.7", features = ["io"] }
 which = { version = "8.0.5" }

--- a/deny.toml
+++ b/deny.toml
@@ -28,4 +28,8 @@ allow = [
   "Unicode-3.0",
   "Zlib",
 ]
+exceptions = [
+  # Root certificate data used by OpenDAL's TLS stack.
+  { crate = "webpki-root-certs", allow = ["CDLA-Permissive-2.0"] },
+]
 unused-allowed-license = "allow"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,217 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+
+use clap::{Args, Parser, Subcommand, ValueEnum};
+
+#[derive(Debug, Parser)]
+#[command(version, about = "OpenDAL filesystem")]
+pub(crate) struct Cli {
+    #[command(subcommand)]
+    pub(crate) command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum Command {
+    /// Collect unreachable Managed objects.
+    Gc(GcArgs),
+    /// Reconcile a local replica with a Managed volume.
+    Sync(SyncArgs),
+    /// Report the durable state of a local Managed Sync replica.
+    Status(StatusArgs),
+    /// Create and inspect filesystem volumes.
+    Volume(VolumeArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct RuntimeArgs {
+    #[arg(
+        long,
+        env = "OFS_TRANSFER_CONCURRENCY",
+        default_value = "4",
+        value_name = "N"
+    )]
+    pub(crate) transfer_concurrency: NonZeroUsize,
+
+    #[arg(
+        long,
+        default_value = "256MiB",
+        value_name = "SIZE",
+        value_parser = parse_size
+    )]
+    pub(crate) work_memory: u64,
+
+    #[arg(
+        long,
+        default_value = "1MiB",
+        value_name = "SIZE",
+        value_parser = parse_size
+    )]
+    pub(crate) read_merge_gap: u64,
+}
+
+impl RuntimeArgs {
+    pub(crate) fn volume_runtime(&self) -> Result<ofs_core::VolumeRuntime, String> {
+        let work_memory = usize::try_from(self.work_memory)
+            .ok()
+            .and_then(NonZeroUsize::new)
+            .ok_or_else(|| String::from("--work-memory must be a positive platform size"))?;
+        let read_gap = usize::try_from(self.read_merge_gap)
+            .map_err(|_| String::from("--read-merge-gap overflows this platform"))?;
+        Ok(ofs_core::VolumeRuntime::new(
+            self.transfer_concurrency,
+            work_memory,
+            read_gap,
+            None,
+        ))
+    }
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct GcArgs {
+    pub(crate) volume: String,
+    #[command(flatten)]
+    pub(crate) runtime: RuntimeArgs,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SyncArgs {
+    pub(crate) volume: String,
+    pub(crate) replica: PathBuf,
+    #[arg(long, value_name = "PATH")]
+    pub(crate) state: PathBuf,
+    #[arg(long, value_name = "RELATIVE-PATH")]
+    pub(crate) resolve: Vec<String>,
+    #[arg(long, value_name = "PATH")]
+    pub(crate) change_set: Option<PathBuf>,
+    #[arg(long, value_enum, value_name = "CAPABILITY")]
+    pub(crate) require: Vec<Capability>,
+    #[command(flatten)]
+    pub(crate) runtime: RuntimeArgs,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct StatusArgs {
+    pub(crate) replica: PathBuf,
+    #[arg(long, value_name = "PATH")]
+    pub(crate) state: PathBuf,
+    #[arg(long)]
+    pub(crate) json: bool,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub(crate) enum Capability {
+    Executable,
+    HardLink,
+    PortableNames,
+    StableRenameIdentity,
+    SymbolicLink,
+    Xattr,
+}
+
+impl Capability {
+    pub(crate) const fn available(self) -> bool {
+        match self {
+            Self::Executable => cfg!(unix),
+            Self::PortableNames => true,
+            Self::HardLink | Self::StableRenameIdentity | Self::SymbolicLink | Self::Xattr => false,
+        }
+    }
+
+    pub(crate) const fn name(self) -> &'static str {
+        match self {
+            Self::Executable => "executable",
+            Self::HardLink => "hard-link",
+            Self::PortableNames => "portable-names",
+            Self::StableRenameIdentity => "stable-rename-identity",
+            Self::SymbolicLink => "symbolic-link",
+            Self::Xattr => "xattr",
+        }
+    }
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct VolumeArgs {
+    #[command(subcommand)]
+    pub(crate) command: VolumeCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum VolumeCommand {
+    /// Create a new volume in empty storage.
+    Create(VolumeCreateArgs),
+    /// Inspect a volume by its local name.
+    Inspect(VolumeInspectArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct VolumeCreateArgs {
+    /// Local volume name resolved by later commands.
+    pub(crate) volume: String,
+
+    /// Namespace authority model.
+    #[arg(long, value_enum, value_name = "MODEL")]
+    pub(crate) model: VolumeModel,
+
+    /// OpenDAL storage URL. Provider credentials come from the environment.
+    #[arg(long, env = "OFS_STORAGE_URL", value_name = "URL")]
+    pub(crate) storage: String,
+
+    /// Shared data-segment rotation target.
+    #[arg(
+        long,
+        value_name = "SIZE",
+        default_value = "8MiB",
+        value_parser = parse_size
+    )]
+    pub(crate) data_segment_target_size: u64,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct VolumeInspectArgs {
+    /// Local volume name.
+    pub(crate) volume: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub(crate) enum VolumeModel {
+    Managed,
+}
+
+pub(crate) fn parse_size(value: &str) -> Result<u64, String> {
+    let value = value.trim();
+    let (digits, multiplier) = if let Some(digits) = value.strip_suffix("GiB") {
+        (digits, 1024 * 1024 * 1024)
+    } else if let Some(digits) = value.strip_suffix("MiB") {
+        (digits, 1024 * 1024)
+    } else if let Some(digits) = value.strip_suffix("KiB") {
+        (digits, 1024)
+    } else if let Some(digits) = value.strip_suffix('B') {
+        (digits, 1)
+    } else {
+        (value, 1)
+    };
+    let count = digits
+        .trim()
+        .parse::<u64>()
+        .map_err(|_| format!("invalid size {value}"))?;
+    count
+        .checked_mul(multiplier)
+        .ok_or_else(|| format!("size {value} overflows"))
+}

--- a/src/command/gc.rs
+++ b/src/command/gc.rs
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use anyhow::Result;
+
+use crate::cli::GcArgs;
+
+pub(super) async fn run(args: GcArgs) -> Result<()> {
+    let volume = super::open_named_volume(&args.volume, &args.runtime).await?;
+    let outcome = volume.collect().await.map_err(anyhow::Error::msg)?;
+    println!(
+        "collected managed volume {}: scanned {}, deleted {} object(s), {} byte(s)",
+        volume.id(),
+        outcome.scanned,
+        outcome.deleted,
+        outcome.deleted_bytes
+    );
+    Ok(())
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+mod gc;
+mod operator;
+mod status;
+mod sync;
+mod volume;
+
+use anyhow::Result;
+use ofs_core::{CoreAccess, ManagedVolume};
+
+use crate::cli::{Cli, Command, RuntimeArgs};
+use crate::locator::VolumeLocator;
+
+use operator::open_storage;
+
+pub(crate) async fn run(cli: Cli) -> Result<()> {
+    match cli.command {
+        Command::Gc(args) => gc::run(args).await,
+        Command::Sync(args) => sync::run(args).await,
+        Command::Status(args) => status::run(args),
+        Command::Volume(args) => volume::run(args).await,
+    }
+}
+
+async fn open_named_volume(name: &str, runtime: &RuntimeArgs) -> Result<ManagedVolume<CoreAccess>> {
+    let record = VolumeLocator::from_env()?.resolve(name)?;
+    let operator = open_storage(&record.storage)?;
+    let runtime = runtime.volume_runtime().map_err(anyhow::Error::msg)?;
+    ManagedVolume::open(&operator, CoreAccess::default(), runtime, "main")
+        .await
+        .map_err(anyhow::Error::msg)
+}

--- a/src/command/operator.rs
+++ b/src/command/operator.rs
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use anyhow::{Result, anyhow};
+use opendal::Operator;
+use opendal::layers::{RetryLayer, TimeoutLayer};
+
+pub(super) fn open_storage(storage: &str) -> Result<Operator> {
+    Operator::from_uri(fs_uri(storage))
+        .map(|operator| {
+            operator
+                .layer(TimeoutLayer::new())
+                .layer(RetryLayer::new().with_jitter())
+        })
+        .map_err(|error| {
+            anyhow!(
+                "cannot configure --storage ({}); check its scheme, endpoint, bucket, and root",
+                error.kind()
+            )
+        })
+}
+
+/// OpenDAL's `fs` URI parser prefixes the path with `/`.
+///
+/// `fs:///C:/Users/...` therefore becomes `/C:/Users/...`, which Windows cannot
+/// canonicalize. Pass the drive path as `?root=` instead.
+fn fs_uri(storage: &str) -> String {
+    let Some(rest) = storage
+        .strip_prefix("fs://")
+        .or_else(|| storage.strip_prefix("file://"))
+    else {
+        return storage.to_owned();
+    };
+    if rest.contains("root=") {
+        return storage.to_owned();
+    }
+    let path = rest
+        .split_once('?')
+        .map(|(path, _)| path)
+        .unwrap_or(rest)
+        .replace('\\', "/");
+    let path = path.trim_start_matches('/');
+    if path.len() >= 2 && path.as_bytes()[0].is_ascii_alphabetic() && path.as_bytes()[1] == b':' {
+        return format!("fs:///?root={path}");
+    }
+    storage.to_owned()
+}

--- a/src/command/status.rs
+++ b/src/command/status.rs
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fs;
+
+use anyhow::{Context, Result, bail};
+use ofs_core::sync::load_replica_state;
+
+use crate::cli::StatusArgs;
+
+pub(super) fn run(args: StatusArgs) -> Result<()> {
+    let root = fs::canonicalize(&args.replica)
+        .with_context(|| format!("cannot open replica directory: {}", args.replica.display()))?;
+    let state = load_replica_state(&args.state)
+        .map_err(anyhow::Error::msg)?
+        .ok_or_else(|| anyhow::anyhow!("replica state does not exist: {}", args.state.display()))?;
+    if state.root() != root {
+        bail!("replica state belongs to a different local directory");
+    }
+    if args.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "access_model": "sync",
+                "base_expired": state.base_expired(),
+                "conflicts": state.conflict_count(),
+                "common_sequence": state.common_revision().cursor().sequence(),
+                "pending": state.has_pending(),
+                "remote_sequence": state.remote_cursor().sequence(),
+                "volume_id": state.volume_id().to_string(),
+                "volume_model": "managed",
+                "capabilities": {
+                    "executable": cfg!(unix),
+                    "extended_attributes": false,
+                    "hard_links": false,
+                    "namespace_publication": "generation_cas",
+                    "portable_names": true,
+                    "remote_durability": "explicit_sync",
+                    "stable_rename_identity": false,
+                    "symbolic_links": false,
+                },
+            })
+        );
+    } else {
+        print!(
+            "managed sync volume {} at change {}, {} pending, {} conflict(s)",
+            state.volume_id(),
+            state.common_revision().cursor().sequence(),
+            usize::from(state.has_pending()),
+            state.conflict_count()
+        );
+        if state.base_expired() {
+            print!(", base expiration detected");
+        }
+        println!();
+    }
+    Ok(())
+}

--- a/src/command/sync.rs
+++ b/src/command/sync.rs
@@ -1,0 +1,146 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fs;
+use std::io::BufRead as _;
+use std::ops::Range;
+
+use anyhow::{Context, Result, anyhow, bail};
+use ofs_core::filesystem::{ContentRef, Digest};
+use ofs_core::sync::{FileChangeSetEntry, SyncEngine};
+
+use crate::cli::SyncArgs;
+
+pub(super) async fn run(args: SyncArgs) -> Result<()> {
+    let root = fs::canonicalize(&args.replica)
+        .with_context(|| format!("cannot open replica directory: {}", args.replica.display()))?;
+    if !root.is_dir() {
+        bail!("replica is not a directory: {}", args.replica.display());
+    }
+    if let Some(capability) = args
+        .require
+        .iter()
+        .find(|capability| !capability.available())
+    {
+        bail!(
+            "required filesystem capability is unavailable: {}",
+            capability.name()
+        );
+    }
+
+    let volume = super::open_named_volume(&args.volume, &args.runtime).await?;
+    let volume_id = volume.id();
+    let engine = SyncEngine::new(volume);
+    let result = match &args.change_set {
+        Some(path) => {
+            let mutations = read_changes(path)?;
+            engine
+                .sync_with_mutations(&root, &args.state, &args.resolve, &mutations)
+                .await?
+        }
+        None => engine.sync(&root, &args.state, &args.resolve).await?,
+    };
+    if !result.conflict_paths.is_empty() {
+        let paths = result
+            .conflict_paths
+            .iter()
+            .map(|path| format!("  {path}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        bail!(
+            "sync retained {} conflict(s); rerun with `--resolve <relative-path>` for each normalized relative path:\n{}",
+            result.conflict_paths.len(),
+            paths
+        );
+    }
+    println!(
+        "synced managed volume {} at change {}{}",
+        volume_id,
+        result.sequence,
+        if result.published { " (published)" } else { "" }
+    );
+    Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct ChangeInput {
+    path: String,
+    base: ContentInput,
+    ranges: Vec<RangeInput>,
+}
+
+#[derive(serde::Deserialize)]
+struct ContentInput {
+    digest: String,
+    length: u64,
+}
+
+#[derive(serde::Deserialize)]
+struct RangeInput {
+    offset: u64,
+    length: u64,
+}
+
+fn read_changes(path: &std::path::Path) -> Result<Vec<FileChangeSetEntry>> {
+    let file = fs::File::open(path)
+        .with_context(|| format!("cannot open staged changes: {}", path.display()))?;
+    std::io::BufReader::new(file)
+        .lines()
+        .enumerate()
+        .filter_map(|(line, input)| match input {
+            Ok(input) if input.trim().is_empty() => None,
+            input => Some((line, input)),
+        })
+        .map(|(line, input)| {
+            let input =
+                input.with_context(|| format!("cannot read staged changes line {}", line + 1))?;
+            let change: ChangeInput = serde_json::from_str(&input)
+                .with_context(|| format!("invalid staged changes line {}", line + 1))?;
+            let digest = decode_digest(&change.base.digest)
+                .with_context(|| format!("invalid digest on staged changes line {}", line + 1))?;
+            let ranges = change
+                .ranges
+                .into_iter()
+                .map(|range| {
+                    let end = range
+                        .offset
+                        .checked_add(range.length)
+                        .ok_or_else(|| anyhow!("changed range overflows on line {}", line + 1))?;
+                    Ok::<Range<u64>, anyhow::Error>(range.offset..end)
+                })
+                .collect::<Result<Vec<_>>>()?;
+            FileChangeSetEntry::new(
+                change.path,
+                ContentRef::new(digest, change.base.length),
+                ranges,
+            )
+            .map_err(anyhow::Error::msg)
+        })
+        .collect()
+}
+
+fn decode_digest(value: &str) -> Result<Digest> {
+    if value.len() != 64 {
+        bail!("digest must contain 64 hexadecimal characters");
+    }
+    let mut bytes = [0_u8; 32];
+    for (index, byte) in bytes.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&value[index * 2..index * 2 + 2], 16)
+            .context("digest contains a non-hexadecimal character")?;
+    }
+    Ok(Digest::from_bytes(bytes))
+}

--- a/src/command/volume.rs
+++ b/src/command/volume.rs
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use anyhow::Result;
+use ofs_core::format::FileDataLayout;
+use ofs_core::{CoreAccess, CreateOptions, ManagedVolume, VolumeRuntime};
+
+use crate::cli::{VolumeArgs, VolumeCommand, VolumeCreateArgs, VolumeInspectArgs};
+use crate::locator::{VolumeLocator, model_name};
+
+use super::operator::open_storage;
+
+pub(super) async fn run(args: VolumeArgs) -> Result<()> {
+    match args.command {
+        VolumeCommand::Create(args) => create(args).await,
+        VolumeCommand::Inspect(args) => inspect(args).await,
+    }
+}
+
+async fn create(args: VolumeCreateArgs) -> Result<()> {
+    let crate::cli::VolumeModel::Managed = args.model;
+    let locator = VolumeLocator::from_env()?;
+    locator.create(&args.volume, args.model, &args.storage)?;
+    let operator = open_storage(&args.storage)?;
+    let layout = FileDataLayout::whole_identity(args.data_segment_target_size)
+        .map_err(anyhow::Error::msg)?;
+    let volume = ManagedVolume::create(
+        &operator,
+        CreateOptions::new(layout),
+        CoreAccess::default(),
+        VolumeRuntime::standard(),
+        "main",
+    )
+    .await
+    .map_err(anyhow::Error::msg)?;
+    println!("created managed volume {} ({})", args.volume, volume.id());
+    Ok(())
+}
+
+async fn inspect(args: VolumeInspectArgs) -> Result<()> {
+    let locator = VolumeLocator::from_env()?;
+    let record = locator.resolve(&args.volume)?;
+    let operator = open_storage(&record.storage)?;
+    let volume = ManagedVolume::open(
+        &operator,
+        CoreAccess::default(),
+        VolumeRuntime::standard(),
+        "main",
+    )
+    .await
+    .map_err(anyhow::Error::msg)?;
+    let format = volume.format();
+    println!("volume {}", args.volume);
+    println!("model {}", model_name(record.model));
+    println!("layout v0");
+    println!("id {}", format.volume_id());
+    println!(
+        "data-segment-target-size {}B",
+        format.file_data_layout().data_segment_target_bytes()
+    );
+    Ok(())
+}

--- a/src/locator.rs
+++ b/src/locator.rs
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Local volume name to storage URL resolver.
+
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, anyhow, bail};
+use ofs_core::filesystem::validate_volume_name;
+
+use crate::cli::VolumeModel;
+
+/// One locally registered volume.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct VolumeRecord {
+    pub(crate) name: String,
+    pub(crate) model: VolumeModel,
+    pub(crate) storage: String,
+}
+
+pub(crate) struct VolumeLocator {
+    home: PathBuf,
+}
+
+impl VolumeLocator {
+    pub(crate) fn from_env() -> Result<Self> {
+        if let Ok(home) = std::env::var("OFS_HOME") {
+            return Ok(Self {
+                home: PathBuf::from(home),
+            });
+        }
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .ok_or_else(|| anyhow!("cannot determine OFS home; set OFS_HOME"))?;
+        Ok(Self {
+            home: PathBuf::from(home).join(".ofs"),
+        })
+    }
+
+    pub(crate) fn create(&self, name: &str, model: VolumeModel, storage: &str) -> Result<()> {
+        validate_volume_name(name).map_err(anyhow::Error::msg)?;
+        if storage.trim().is_empty() {
+            bail!("--storage is empty");
+        }
+        fs::create_dir_all(self.volumes_dir()).with_context(|| {
+            format!(
+                "cannot create volume directory {}",
+                self.volumes_dir().display()
+            )
+        })?;
+        let path = self.record_path(name);
+        if path.exists() {
+            let existing = self.resolve(name)?;
+            if existing.model != model || existing.storage != storage {
+                bail!("volume {name} already exists with a different storage locator");
+            }
+            return Ok(());
+        }
+        let body = format!("model=managed\nstorage={storage}\n");
+        fs::write(&path, body)
+            .with_context(|| format!("cannot write volume locator {}", path.display()))
+    }
+
+    pub(crate) fn resolve(&self, name: &str) -> Result<VolumeRecord> {
+        validate_volume_name(name).map_err(anyhow::Error::msg)?;
+        let path = self.record_path(name);
+        let body = fs::read_to_string(&path).with_context(|| {
+            format!(
+                "cannot read volume locator {}; create the volume first",
+                path.display()
+            )
+        })?;
+        parse_record(name, &body)
+    }
+
+    fn volumes_dir(&self) -> PathBuf {
+        self.home.join("volumes")
+    }
+
+    fn record_path(&self, name: &str) -> PathBuf {
+        self.volumes_dir().join(name)
+    }
+}
+
+fn parse_record(name: &str, body: &str) -> Result<VolumeRecord> {
+    let mut model = None;
+    let mut storage = None;
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            bail!("volume locator has an invalid line");
+        };
+        match key {
+            "model" if value == "managed" => model = Some(VolumeModel::Managed),
+            "storage" => storage = Some(value.to_owned()),
+            _ => bail!("volume locator has an unknown field {key}"),
+        }
+    }
+    Ok(VolumeRecord {
+        name: name.to_owned(),
+        model: model.ok_or_else(|| anyhow!("volume locator is missing model"))?,
+        storage: storage.ok_or_else(|| anyhow!("volume locator is missing storage"))?,
+    })
+}
+
+pub(crate) fn model_name(_model: VolumeModel) -> &'static str {
+    "managed"
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+mod cli;
+mod command;
+mod locator;
+
+use anyhow::Result;
+use clap::Parser as _;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = cli::Cli::parse();
+    command::run(cli).await
+}


### PR DESCRIPTION
This PR exposes managed volume workflows through `ofs`.

It adds volume creation, sync, status, and garbage collection commands, together with managed volume locator resolution. The acceptance harness is out of scope.

Depends on #36. Part of #26.

Parts of this PR were written with AI assistance. I reviewed the code and take responsibility for it.

## Validation

- `cargo x lint`
- `cargo x check`
- `cargo x test`
- `cargo x licenses`
