### PR TITLE
refactor: rename project to Apache OpenDAL™ YinYang

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,7 +18,7 @@
 # All configurations could be found here: https://github.com/apache/infrastructure-asfyaml/
 
 github:
-  description: "A userspace filesystem backing by Apache OpenDAL."
+  description: "Apache OpenDAL™ YinYang: a cross-platform filesystem foundation."
   homepage: https://opendal.apache.org
   labels:
     - rust

--- a/.github/ISSUE_TEMPLATE/3-new-release.md
+++ b/.github/ISSUE_TEMPLATE/3-new-release.md
@@ -1,10 +1,10 @@
 ---
 name: New Release
 about: Use this template for start making a new release
-title: "Tracking issues of Apache OpenDAL ofs (opendal-ofs) ${opendal_ofs_version} Release"
+title: "Tracking issues of Apache OpenDAL™ YinYang ${yinyang_version} Release"
 ---
 
-This issue is used to track tasks of the Apache OpenDAL ofs (opendal-ofs) ${opendal_ofs_version} release.
+This issue tracks the Apache OpenDAL™ YinYang ${yinyang_version} release.
 
 ## Tasks
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -18,8 +18,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Question
-    url: https://github.com/apache/opendal-ofs/discussions/new?category=q-a
-    about: Ask questions about Apache OpenDAL ofs (opendal-ofs) usage and development.
+    url: https://github.com/apache/opendal-yinyang/discussions/new?category=q-a
+    about: Ask questions about Apache OpenDAL™ YinYang usage and development.
   - name: Discord
     url: https://opendal.apache.org/discord
-    about: Join the Apache OpenDAL Discord for real-time discussions about opendal-ofs.
+    about: Join the Apache OpenDAL Discord for discussions about Apache OpenDAL™ YinYang.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Ofs CI
+name: Apache OpenDAL™ YinYang CI
 
 on:
   pull_request:
@@ -61,15 +61,15 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
-      OFS_MSRV: "1.91.0"
+      YINYANG_MSRV: "1.91.0"
     steps:
       - uses: actions/checkout@v7
 
       - name: Install Rust MSRV
-        run: rustup toolchain install "$OFS_MSRV"
+        run: rustup toolchain install "$YINYANG_MSRV"
 
       - name: Check with Rust MSRV
-        run: cargo +"$OFS_MSRV" check --workspace --all-targets --locked
+        run: cargo +"$YINYANG_MSRV" check --workspace --all-targets --locked
 
   test:
     name: Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for contributing to Apache OpenDAL™ File System.
+Thank you for contributing to Apache OpenDAL™ YinYang.
 
 ## Set up the repository
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,10 +117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
-name = "ofs"
-version = "0.0.24"
-
-[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,3 +200,7 @@ dependencies = [
  "clap",
  "which",
 ]
+
+[[package]]
+name = "yinyang"
+version = "0.0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@
 
 [package]
 categories = ["filesystem"]
-description = "Apache OpenDAL File System"
+description = "Apache OpenDAL™ YinYang"
 keywords = ["storage", "filesystem"]
-name = "ofs"
+name = "yinyang"
 version = "0.0.24"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
@@ -38,7 +38,7 @@ resolver = "3"
 edition = "2024"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
-repository = "https://github.com/apache/opendal-ofs"
+repository = "https://github.com/apache/opendal-yinyang"
 rust-version = "1.91.0"
 
 [workspace.dependencies]

--- a/DEPENDENCIES.rust.tsv
+++ b/DEPENDENCIES.rust.tsv
@@ -1,2 +1,2 @@
 crate	Apache-2.0
-ofs@0.0.24	X
+yinyang@0.0.24	X

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Apache OpenDAL ofs
+Apache OpenDAL YinYang
 Copyright 2025 The Apache Software Foundation
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -1,36 +1,36 @@
-# Apache OpenDAL™ File System
+# Apache OpenDAL™ YinYang
 
 [![Build Status]][actions] [![Latest Version]][crates.io] [![Crate Downloads]][crates.io] [![MSRV 1.91.0]][msrv] [![Apache 2.0 licensed]][license] [![chat]][discord]
 
-[build status]: https://img.shields.io/github/actions/workflow/status/apache/opendal-ofs/ci.yml?branch=main
-[actions]: https://github.com/apache/opendal-ofs/actions?query=branch%3Amain
-[latest version]: https://img.shields.io/crates/v/ofs.svg
-[crates.io]: https://crates.io/crates/ofs
-[crate downloads]: https://img.shields.io/crates/d/ofs.svg
+[build status]: https://img.shields.io/github/actions/workflow/status/apache/opendal-yinyang/ci.yml?branch=main
+[actions]: https://github.com/apache/opendal-yinyang/actions?query=branch%3Amain
+[latest version]: https://img.shields.io/crates/v/yinyang.svg
+[crates.io]: https://crates.io/crates/yinyang
+[crate downloads]: https://img.shields.io/crates/d/yinyang.svg
 [msrv 1.91.0]: https://img.shields.io/badge/MSRV-1.91.0-green?logo=rust
 [msrv]: https://www.whatrustisit.com
-[apache 2.0 licensed]: https://img.shields.io/crates/l/ofs
+[apache 2.0 licensed]: https://img.shields.io/crates/l/yinyang
 [license]: https://www.apache.org/licenses/LICENSE-2.0
 [chat]: https://img.shields.io/discord/1081052318650339399
 [discord]: https://opendal.apache.org/discord
 
-`ofs` is the Apache OpenDAL filesystem project.
+Apache OpenDAL™ YinYang is a cross-platform filesystem foundation.
 
 > [!IMPORTANT]
 > **Status: active redesign**
 >
-> We are actively working on the design of the next `ofs` release under
+> We are actively working on the design of the next Apache OpenDAL™ YinYang release under
 > [RFC-0016]. The `main` branch is a buildable project scaffold and does not
 > currently provide a mount command or runtime API.
 
 ## Previous releases
 
-The implementation used by earlier published releases is preserved on the
-[`backup`] branch. It predates RFC-0016 and remains available for reference
-while the new runtime is designed.
+The [`backup`] branch preserves the implementation released as Apache OpenDAL™ File System.
+Its Cargo package and command-line executable are both named `ofs`.
+This historical implementation predates the YinYang redesign and remains available for reference.
 
 [rfc-0016]: rfcs/0016_filesystem_architecture.md
-[`backup`]: https://github.com/apache/opendal-ofs/tree/backup
+[`backup`]: https://github.com/apache/opendal-yinyang/tree/backup
 
 ## Development
 
@@ -45,7 +45,11 @@ cargo x licenses
 
 ## Branding
 
-The first and most prominent mentions must use the full form: **Apache OpenDAL™** of the name for any individual usage (webpage, handout, slides, etc.) Depending on the context and writing style, you should use the full form of the name sufficiently often to ensure that readers clearly understand the association of both the OpenDAL project and the OpenDAL software product to the ASF as the parent organization.
+Apache OpenDAL™ is the ASF project and umbrella brand. Apache OpenDAL™ YinYang software is a product developed by the Apache OpenDAL project.
+
+Use the full product name, **Apache OpenDAL™ YinYang**, in titles and first prominent references. Later references may use **YinYang** when the relationship to the Apache OpenDAL project and the ASF remains clear.
+
+Use `yinyang` only for the Cargo package and Rust crate, and use `yy` only for the command-line executable and commands. The former product name **Apache OpenDAL™ File System** and the `ofs` package and executable refer only to historical releases preserved on the [`backup`] branch.
 
 For more details, see the [Apache Product Name Usage Guide](https://www.apache.org/foundation/marks/guide).
 
@@ -53,4 +57,4 @@ For more details, see the [Apache Product Name Usage Guide](https://www.apache.o
 
 Licensed under the Apache License, Version 2.0: <http://www.apache.org/licenses/LICENSE-2.0>
 
-Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.
+Apache OpenDAL, OpenDAL, Apache OpenDAL YinYang, YinYang, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/rfcs/0016_filesystem_architecture.md
+++ b/rfcs/0016_filesystem_architecture.md
@@ -1,19 +1,16 @@
 - Proposal Name: `filesystem_architecture`
 - Start Date: 2026-07-30
-- RFC PR: [apache/opendal-ofs#16](https://github.com/apache/opendal-ofs/pull/16)
-- Tracking Issue: [apache/opendal-ofs#19](https://github.com/apache/opendal-ofs/issues/19)
+- RFC PR: [apache/opendal-yinyang#16](https://github.com/apache/opendal-yinyang/pull/16)
+- Tracking Issue: [apache/opendal-yinyang#19](https://github.com/apache/opendal-yinyang/issues/19)
 
 > [!NOTE]
-> **Update, August 10, 2026:** `main` no longer contains the previous Direct
-> Mount implementation. Its source is preserved on the
-> [`backup`](https://github.com/apache/opendal-ofs/tree/backup) branch while the
-> new implementation is designed. The RFC below remains unchanged.
+> **Update, August 10, 2026:** `main` no longer contains the Direct Mount implementation released as Apache OpenDAL™ File System (`ofs`). Its source is preserved on the [`backup`](https://github.com/apache/opendal-yinyang/tree/backup) branch while the new implementation is designed. The architecture described below is unchanged.
 
 # Summary
 
-Define ofs as a cross-platform filesystem engine with two independent choices.
+Define Apache OpenDAL™ YinYang as a cross-platform filesystem engine with two independent choices.
 A **Volume Model** selects either `Direct`, where an existing storage namespace
-is authoritative, or `Managed`, where ofs metadata owns the filesystem
+is authoritative, or `Managed`, where YinYang metadata owns the filesystem
 namespace and storage holds immutable file data. An **Access Model** selects
 either `Mount`, which presents an online remote filesystem, or `Sync`, which
 reconciles a local native filesystem with a volume.
@@ -21,7 +18,7 @@ reconciles a local native filesystem with a volume.
 The same filesystem contract is implemented by OS-specific mount and sync
 frontends. FUSE, filesystem extensions, user-mode drivers, placeholder APIs,
 and network filesystem protocols are transports for that contract rather than
-separate ofs storage modes.
+separate YinYang storage modes.
 
 # Motivation
 
@@ -39,7 +36,7 @@ Deriving those concepts from object names is useful for browsing existing data,
 but it cannot provide the same guarantees as a namespace backed by filesystem
 metadata.
 
-ofs users need both outcomes:
+YinYang users need both outcomes:
 
 - access existing storage without importing or rewriting it;
 - use storage as the data plane for a reliable filesystem;
@@ -54,8 +51,7 @@ POSIX label for behavior that only some combinations can enforce.
 
 ## The two-axis model
 
-Every ofs volume has one Volume Model and can be accessed through either Access
-Model:
+Every YinYang volume has one Volume Model and can be accessed through either Access Model:
 
 | Volume Model | Mount | Sync |
 | --- | --- | --- |
@@ -72,11 +68,11 @@ A Direct volume maps storage paths to filesystem paths without creating
 authoritative remote metadata:
 
 ```text
-ofs volume create archive \
+yy volume create archive \
   --model direct \
   --storage <storage-url>
 
-ofs mount archive /mnt/archive --read-only
+yy mount archive /mnt/archive --read-only
 ```
 
 Objects remain readable by existing storage tools. Direct volumes are suitable
@@ -96,17 +92,17 @@ enabled explicitly.
 A Managed volume stores files through a metadata namespace:
 
 ```text
-ofs volume create workspace \
+yy volume create workspace \
   --model managed \
   --storage <storage-url>
 
-ofs mount workspace /mnt/workspace
+yy mount workspace /mnt/workspace
 ```
 
-Applications see stable files and directories. ofs metadata owns node
+Applications see stable files and directories. YinYang metadata owns node
 identity, directory entries, attributes, content versions, and generations.
 Storage contains immutable file data referenced by metadata. The storage
-prefix is private to ofs and must not be modified by external writers.
+prefix is private to YinYang and must not be modified by external writers.
 
 The metadata provider may use an embedded database, a remote database, or
 metadata objects. The deployment choice is hidden behind one transaction and
@@ -128,34 +124,34 @@ Mount and Sync have deliberately different acknowledgement semantics:
 | Conflict reporting | Filesystem error | Conflict record and retained content |
 | Local disk usage | Evictable cache and staging | Materialized tree and state database |
 
-`ofs mount` selects a frontend supported by the host. A user asks for a mount,
+`yy mount` selects a frontend supported by the host. A user asks for a mount,
 not for FUSE as a product mode:
 
 ```text
-ofs mount <volume> <mount-path>
+yy mount <volume> <mount-path>
 ```
 
 A Linux FUSE frontend, a platform filesystem extension, a user-mode driver, or
 a loopback network filesystem can implement the same Mount contract. Selecting
 a different frontend cannot strengthen the volume's capabilities.
 
-`ofs sync` reconciles a volume with an ordinary local directory:
+`yy sync` reconciles a volume with an ordinary local directory:
 
 ```text
-ofs sync <volume> <local-directory>
-ofs status <local-directory>
+yy sync <volume> <local-directory>
+yy status <local-directory>
 ```
 
 Local writes remain available while disconnected. Remote publication has a
 separate status and explicit wait operation. When both sides change from the
-same base generation and cannot be merged, ofs retains both contents and
+same base generation and cannot be merged, YinYang retains both contents and
 reports a conflict instead of choosing the last writer.
 
 ## Required contracts and optional capabilities
 
 Selecting `Direct` or `Managed` and `Mount` or `Sync` is the complete
 user-facing mode selection. Each choice contributes the mandatory contract
-described above. ofs does not add another semantic bundle that weakens or
+described above. YinYang does not add another semantic bundle that weakens or
 rebundles those guarantees; a combination that cannot satisfy its selected
 models fails to start.
 
@@ -163,12 +159,12 @@ Operations outside the baseline are reported individually. A user can require
 them when starting an access model:
 
 ```text
-ofs mount workspace /mnt/workspace \
+yy mount workspace /mnt/workspace \
   --require hard-link \
   --require xattr
 ```
 
-Missing requirements fail before the mount becomes visible. `ofs status`
+Missing requirements fail before the mount becomes visible. `yy status`
 reports effective capabilities, pending writes, conflicts, and the local and
 remote durability positions.
 
@@ -176,7 +172,7 @@ remote durability positions.
 
 ## Architecture boundaries
 
-ofs is divided into four responsibilities:
+YinYang is divided into four responsibilities:
 
 ```text
 OS frontend
@@ -199,7 +195,7 @@ baseline validation, capability reporting, cache policy, and error semantics.
 A Volume implementation owns namespace authority and publication. An OS
 frontend translates native operations without changing their guarantees.
 OpenDAL provides storage primitives and their native capabilities; it does not
-emulate filesystem transactions for ofs.
+emulate filesystem transactions for YinYang.
 
 The core contract includes these logical identities:
 
@@ -251,9 +247,9 @@ The storage namespace is the only remote authority for a Direct volume:
 - directories, inode numbers, and unsupported attributes are derived;
 - external storage writers are valid concurrent writers; and
 - local caches, indexes, staging files, and recovery journals are allowed, but
-  no remote ofs metadata becomes namespace authority.
+  no remote YinYang metadata becomes namespace authority.
 
-Pure storage means that ofs does not require an additional remote metadata
+Pure storage means that YinYang does not require an additional remote metadata
 model. It does not require stateless clients. Pending local writes and
 multi-step operations must be journaled until they are committed, cancelled,
 or recovered.
@@ -325,14 +321,14 @@ A Mount frontend presents the remote volume as the authority. Local data is an
 evictable cache or recoverable staging state.
 
 `write` may acknowledge data accepted into a local writeback cache. `flush`
-attempts publication. `fsync` succeeds only after ofs has completed remote data
+attempts publication. `fsync` succeeds only after YinYang has completed remote data
 publication and the required metadata commit according to the backend's
 acknowledged durability contract. If the network or remote commit is
 unavailable, `fsync` fails.
 
 Asynchronous writeback errors remain attached to the handle and volume. They
 are returned by a later `flush`, `fsync`, or `close` where the frontend permits,
-and are always visible through `ofs status`.
+and are always visible through `yy status`.
 
 Managed mounts use generations and invalidation to provide their declared
 multi-client visibility. Direct mounts use storage versions and conditional
@@ -439,7 +435,7 @@ but it does not change the selected Volume or Access Model.
 
 FUSE-compatible libraries and user-mode drivers solve an OS transport problem.
 They do not define storage authority, remote durability, or offline conflict
-semantics. Keeping them as frontends allows ofs to adopt the best supported
+semantics. Keeping them as frontends allows YinYang to adopt the best supported
 mechanism on each platform without changing volume behavior.
 
 ## Direct storage only
@@ -491,7 +487,7 @@ from
 [Cloud Files sync providers](https://learn.microsoft.com/en-us/windows/win32/cfapi/build-a-cloud-file-sync-engine).
 These APIs validate the distinction between presenting a remote view and
 reconciling local files, while their platform-specific contracts reinforce the
-need for shared ofs semantics above the frontend.
+need for shared YinYang semantics above the frontend.
 
 # Unresolved questions
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Apache OpenDAL™ File System.
+//! Apache OpenDAL™ YinYang.
 //!
 //! The filesystem architecture is being redesigned. This crate intentionally
 //! exposes no runtime API until the new contracts are ready for implementation.


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

The repository has been renamed to `apache/opendal-yinyang`. This change aligns the codebase with the Apache OpenDAL™ YinYang name before public runtime APIs are introduced.

# What changes are included in this PR?

- Rename product references to Apache OpenDAL™ YinYang, the Cargo package and crate to `yinyang`, and CLI examples to `yy`.
- Update repository metadata, links, CI, templates, and RFC wording.
- Document `backup` as the historical Apache OpenDAL™ File System (`ofs`) implementation.

# Are there any user-facing changes?

Yes. The product and package names change, and the planned executable becomes `yy`. The historical `backup` implementation remains `ofs`.