### PR TITLE
docs: simplify branding guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Apache OpenDAL™ is the ASF project and umbrella brand. Apache OpenDAL™ YinYa
 
 Use the full product name, **Apache OpenDAL™ YinYang**, in titles and first prominent references. Later references may use **YinYang** when the relationship to the Apache OpenDAL project and the ASF remains clear.
 
-Use `yinyang` only for the Cargo package and Rust crate, and use `yy` only for the command-line executable and commands. The former product name **Apache OpenDAL™ File System** and the `ofs` package and executable refer only to historical releases preserved on the [`backup`] branch.
+Use `yinyang` only for the Cargo package and Rust crate, and use `yy` only for the command-line executable and commands.
 
 For more details, see the [Apache Product Name Usage Guide](https://www.apache.org/foundation/marks/guide).
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

The branding guidance should focus on current names and avoid unnecessary historical release wording.

# What changes are included in this PR?

Remove the historical `ofs` statement from the README branding guidance.

# Are there any user-facing changes?

No. This is a documentation-only change.